### PR TITLE
Add plausible config

### DIFF
--- a/helm/flowforge/templates/configmap.yaml
+++ b/helm/flowforge/templates/configmap.yaml
@@ -96,3 +96,11 @@ data:
     logging:
       level: info
       http: info
+    telemetry:
+      enabled: {{ .Values.forge.telemetry.enabled }}
+      {{- if .Values.forge.telemetry.plausible -}}
+      frontend:
+        plausible:
+          domain: {{ .Values.forge.telemetry.plausible }}
+      {{- end -}}
+

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -169,6 +169,17 @@
                     ]
                 }
             },
+            "telemetry": {
+                "type": "object",
+                "properties": {
+                    "enabled": {
+                        "type": "boolean"
+                    },
+                    "plausible": {
+                        "type": "string"
+                    }
+                }
+            },
             "required": [
                 "domain"
             ]

--- a/helm/flowforge/values.yaml
+++ b/helm/flowforge/values.yaml
@@ -10,6 +10,8 @@ forge:
     role: projects
   managementSelector:
     role: management
+  telemetry:
+    enabled: true
 
 postgresql:
   postgresqlPostgresPassword: Moomiet0


### PR DESCRIPTION
Adding in some custom changes to production FF Cloud config file to the standard helm chart to make rebuilding easier