### PR TITLE
Bump version for 0.8.0

### DIFF
--- a/build-containers.sh
+++ b/build-containers.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-TAG=0.7.1
+TAG=0.8.0
 
 REGISTRY=$1
 

--- a/helm/flowforge/Chart.yaml
+++ b/helm/flowforge/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "flowforge"
-version: "0.7.1"
+version: "0.8.0"
 description: "FlowForge"
 type: "application"
 home: "https://flowforge.com"
@@ -16,4 +16,4 @@ dependencies:
 maintainers:
   - name: "FlowForge Inc"
     url: "https://flowforge.com"
-appVersion: "0.7.1"
+appVersion: "0.8.0"


### PR DESCRIPTION
This bumps the versions that are not currently covered by  the prepare-release script