### PR TITLE
Move to docker GH actions

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -11,6 +11,8 @@ jobs:
         with:
           repository: 'flowforge/helm'
           path: 'helm'
+      # sets options for Docker build
+      # will tag contianers with GH tag name
       - name: Docker Meta Data
         uses: docker/metadata-action@v3
         with:
@@ -18,15 +20,19 @@ jobs:
             type=semver,event=tag,pattern={{version}}
           images: |
             flowforge/forge-k8s
+      # sets up multi platform emulators
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v1
+      # sets up docker buildx
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v1
+      # logs into docker hub
       - name: docker login
         uses: docker/login-action@v1
         with:
           username: flowforge
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+      # builds container
       - name: Build and push FlowForge Application container
         uses: docker/build-push-action@v2
         with:
@@ -34,15 +40,6 @@ jobs:
           file: helm/flowforge-contianer/Dockerfile
           platforms: linux/amd64, linux/arm64
           push: true
-      # - name: Build FlowForge application container
-      #   working-directory: helm
-      #   env:
-      #     IMAGE_TAG: ${{ github.ref_name }}
-      #     CONTAINER_NAME: flowforge/forge-k8s
-      #   run: |
-      #     docker build flowforge-container -t $CONTAINER_NAME:$IMAGE_TAG
-      #     echo ${{secrets.DOCKER_HUB_PASSWORD}} | docker login -u flowforge --password-stdin
-      #     docker push $CONTAINER_NAME:$IMAGE_TAG
   build_nodered_container:
     runs-on: ubuntu-latest
     steps:
@@ -75,12 +72,3 @@ jobs:
           file: helm/flowforge-contianer/Dockerfile
           platforms: linux/amd64, linux/arm64
           push: true
-      # - name: Build Node-RED Stack container
-      #   working-directory: helm
-      #   env:
-      #     IMAGE_TAG: ${{ github.ref_name }}
-      #     CONTAINER_NAME: flowforge/node-red
-      #   run: |
-      #     docker build flowforge-container -t $CONTAINER_NAME:$IMAGE_TAG
-      #     echo ${{secrets.DOCKER_HUB_PASSWORD}} | docker login -u flowforge --password-stdin
-      #     docker push $CONTAINER_NAME:$IMAGE_TAG

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -11,15 +11,38 @@ jobs:
         with:
           repository: 'flowforge/helm'
           path: 'helm'
-      - name: Build Node-RED Stack container
-        working-directory: helm
-        env:
-          IMAGE_TAG: ${{ github.ref_name }}
-          CONTAINER_NAME: flowforge/node-red
-        run: |
-          docker build flowforge-container -t $CONTAINER_NAME:$IMAGE_TAG
-          echo ${{secrets.DOCKER_HUB_PASSWORD}} | docker login -u flowforge --password-stdin
-          docker push $CONTAINER_NAME:$IMAGE_TAG
+      - name: Docker Meta Data
+        uses: docker/metadata-action@v3
+        with:
+          tags: |
+            type=semver,event=tag,pattern={{version}}
+          images: |
+            flowforge/forge-k8s
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v1
+      - name: docker login
+        uses: docker/login-action@v1
+        with:
+          username: flowforge
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+      - name: Build and push FlowForge Application container
+        uses: docker/build-push-action@v2
+        with:
+          context: helm/flowforge-container
+          file: helm/flowforge-contianer/Dockerfile
+          platforms: linux/amd64, linux/arm64
+          push: true
+      # - name: Build FlowForge application container
+      #   working-directory: helm
+      #   env:
+      #     IMAGE_TAG: ${{ github.ref_name }}
+      #     CONTAINER_NAME: flowforge/forge-k8s
+      #   run: |
+      #     docker build flowforge-container -t $CONTAINER_NAME:$IMAGE_TAG
+      #     echo ${{secrets.DOCKER_HUB_PASSWORD}} | docker login -u flowforge --password-stdin
+      #     docker push $CONTAINER_NAME:$IMAGE_TAG
   build_nodered_container:
     runs-on: ubuntu-latest
     steps:
@@ -27,12 +50,37 @@ jobs:
         with:
           repository: 'flowforge/helm'
           path: 'helm'
-      - name: Build FlowForge application container
-        working-directory: helm
-        env:
-          IMAGE_TAG: ${{ github.ref_name }}
-          CONTAINER_NAME: flowforge/forge-k8s
-        run: |
-          docker build flowforge-container -t $CONTAINER_NAME:$IMAGE_TAG
-          echo ${{secrets.DOCKER_HUB_PASSWORD}} | docker login -u flowforge --password-stdin
-          docker push $CONTAINER_NAME:$IMAGE_TAG
+      - name: Docker Meta Data
+        uses: docker/metadata-action@v3
+        with:
+          tags: |
+            type=semver,event=tag,pattern={{version}}
+          flavors: |
+            latest=false
+          images: |
+            flowforge/node-red
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v1
+      - name: docker login
+        uses: docker/login-action@v1
+        with:
+          username: flowforge
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+      - name: Build and push FlowForge Application container
+        uses: docker/build-push-action@v2
+        with:
+          context: helm/flowforge-container
+          file: helm/flowforge-contianer/Dockerfile
+          platforms: linux/amd64, linux/arm64
+          push: true
+      # - name: Build Node-RED Stack container
+      #   working-directory: helm
+      #   env:
+      #     IMAGE_TAG: ${{ github.ref_name }}
+      #     CONTAINER_NAME: flowforge/node-red
+      #   run: |
+      #     docker build flowforge-container -t $CONTAINER_NAME:$IMAGE_TAG
+      #     echo ${{secrets.DOCKER_HUB_PASSWORD}} | docker login -u flowforge --password-stdin
+      #     docker push $CONTAINER_NAME:$IMAGE_TAG


### PR DESCRIPTION
This lets us use docker buildx to build multiplatform containers and apply some better rules to the tagging

https://github.com/docker/login-action
https://github.com/docker/metadata-action
https://github.com/docker/setup-qemu-action
https://github.com/docker/setup-buildx-action
https://github.com/docker/build-push-action