### PR TITLE
Push README.md files to Docker Hub with each release

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -42,6 +42,13 @@ jobs:
           platforms: linux/amd64, linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           push: true
+      - name: Push README
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          repository: flowforge/forge-k8s
+          username: flowforge
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          readme-filepath: ./flowforge-container/README.md
   build_nodered_container:
     runs-on: ubuntu-latest
     steps:
@@ -76,3 +83,10 @@ jobs:
           platforms: linux/amd64, linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           push: true
+      - name: Push README
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          repository: flowforge/node-red
+          username: flowforge
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          readme-filepath: ./node-red-contianer/README.md

--- a/flowforge-container/README.md
+++ b/flowforge-container/README.md
@@ -1,0 +1,13 @@
+# FlowForge Kubernetes
+
+The [FlowForge](https://flowforge.com) app with the Kubernetes Container driver bundled.
+
+Expected to be used to the FlowForge [Helm chart](https://github.com/flowforge/helm/)
+
+## Configuration
+
+This container expects a `/usr/src/forge/etc/flowforge.yml` file to be mounted containing the configuration information for this instance of FlowForge.
+
+## Exposed Ports
+
+ - 3000

--- a/node-red-container/README.md
+++ b/node-red-container/README.md
@@ -1,0 +1,11 @@
+# FlowForge Node-RED
+
+A base container to be used for FlowForge Stacks on Kubernetes and Docker Compose based installs.
+
+It builds from the latest Node-RED container and adds following FlowForge packages:
+
+- [FlowForge Storage Plugin](https://github.com/flowforge/flowforge-nr-storage)
+- [FlowForge Authentication Plugin](https://github.com/flowforge/flowforge-nr-auth)
+- [FlowForge Audit Logger Plugin](https://github.com/flowforge/flowforge-nr-audit-logger)
+- [FlowForge Project Nodes](https://github.com/flowforge/flowforge-nr-project-nodes)
+- [FlowForge Theme](https://github.com/flowforge/flowforge-nr-theme)


### PR DESCRIPTION
At the moment the Docker Hub entries are empty.