### PR TITLE
Update helm chart readme about node selectors

### DIFF
--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -27,6 +27,9 @@ This chart uses the Bitnami PostgreSQL Chart to provide an instance of a Postgre
  - `forge.projectNamespace` namespace Project Pods will run in (default `flowforge`)
  - `forge.license` FlowForge EE license string (opional, default not set)
 
+
+note: `forge.projectSelector` and `forge.managementSelector` defaults mean that you must have at least 2 nodes in your cluster and they need to be labeled before installing.
+
 ### AWS
 
 If `forge.cloudProvider` is set to `aws` then the following should be set


### PR DESCRIPTION
Make it clear that the helm chart defaults expects 2 nodes in the cluster.

More instructions in the Kubernetes install instructions in https://github.com/flowforge/flowforge/pull/1229 on how to run on single node cluster