### PR TITLE
Fix indentation in file-server.yml

### DIFF
--- a/helm/flowforge/templates/configmap.yaml
+++ b/helm/flowforge/templates/configmap.yaml
@@ -109,7 +109,7 @@ data:
       http: info
     telemetry:
       enabled: {{ .Values.forge.telemetry.enabled }}
-      {{- if or (.Values.forge.telemetry.plausible) (.Values.forge.telemetry.posthog) -}}
+      {{ if or (.Values.forge.telemetry.plausible) (.Values.forge.telemetry.posthog) -}}
       frontend:
         {{ if .Values.forge.telemetry.plausible -}}
         plausible:

--- a/helm/flowforge/templates/file-storage.yml
+++ b/helm/flowforge/templates/file-storage.yml
@@ -12,10 +12,7 @@ data:
       type: {{ .Values.forge.fileStore.type }}
       {{- if .Values.forge.fileStore.options }}
       options:
-        {{- range $key, $value := .Values.forge.fileStore.options }}
-        {{ $key }}:
-{{ toYaml $value | indent 10 -}}
-        {{- end }}
+{{ toYaml .Values.forge.fileStore.options | indent 8 -}}
       {{- end }}
 ---
 {{ if eq .Values.forge.fileStore.type "localfs" }}


### PR DESCRIPTION
make sure the file-server template formats properly

Also fix a line break in the telemetry section of the flowforge config map