### PR TITLE
Add context store provisioning

### DIFF
--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -83,8 +83,8 @@ Enables FlowForge Telemetry
 
 - `forge.fileStore.enabled` (default `false`)
 - `forge.fileStore.type` Choice of backends to store files `localfs` or `s3` (default `localfs`)
-- `forge.fileStore.options` Options to pass to the backend storage driver 
+- `forge.fileStore.options` Options to pass to the backend storage driver (See [file-server](https://github.com/flowforge/flowforge-file-server) for details)
 - `forge.fileStore.quota` Sets the maximum number of bytes that a project can store as files (default `104857600`)
 - `forge.fileStore.context.type` Choice of backends for Persistent Context `sequelize`
-- `forge.fileStore.context.options` Options to pass to Persistent Context Driver
+- `forge.fileStore.context.options` Options to pass to Persistent Context Driver (See [file-server](https://github.com/flowforge/flowforge-file-server) for details)
 - `forge.fileStore.context.quota` Sets the maximum number of bytes that a project can store in Persistent Context (default `1048576`)

--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -82,9 +82,9 @@ Enables FlowForge Telemetry
 ### File Storage
 
 - `forge.fileStore.enabled` (default `false`)
-- `forge.fileStore.type` Choice of backends to store files `localfs` or `s3`
-- `forge.fileStore.options` Options to pass to the backend storage driver
-- `forge.fileStore.quota` Sets the maximum number of bytes that a project can store as files
+- `forge.fileStore.type` Choice of backends to store files `localfs` or `s3` (default `localfs`)
+- `forge.fileStore.options` Options to pass to the backend storage driver 
+- `forge.fileStore.quota` Sets the maximum number of bytes that a project can store as files (default `104857600`)
 - `forge.fileStore.context.type` Choice of backends for Persistent Context `sequelize`
 - `forge.fileStore.context.options` Options to pass to Persistent Context Driver
-- `forge.fileStore.context.quota` Sets the maximum number of bytes that a project can store in Persistent Context
+- `forge.fileStore.context.quota` Sets the maximum number of bytes that a project can store in Persistent Context (default `1048576`)

--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -84,3 +84,7 @@ Enables FlowForge Telemetry
 - `forge.fileStore.enabled` (default `false`)
 - `forge.fileStore.type` Choice of backends to store files `localfs` or `s3`
 - `forge.fileStore.options` Options to pass to the backend storage driver
+- `forge.fileStore.quota` Sets the maximum number of bytes that a project can store as files
+- `forge.fileStore.context.type` Choice of backends for Persistent Context `sequelize`
+- `forge.fileStore.context.options` Options to pass to Persistent Context Driver
+- `forge.fileStore.context.quota` Sets the maximum number of bytes that a project can store in Persistent Context

--- a/helm/flowforge/templates/file-storage.yml
+++ b/helm/flowforge/templates/file-storage.yml
@@ -10,10 +10,22 @@ data:
     base_url: http://forge.{{ .Release.Namespace }}
     driver:
       type: {{ .Values.forge.fileStore.type }}
+      {{- if .Values.forge.fileStore.quota }}
+      quota: {{ .values.forge.fileStore.quota }}
+      {{- end }}
       {{- if .Values.forge.fileStore.options }}
       options:
 {{ toYaml .Values.forge.fileStore.options | indent 8 -}}
       {{- end }}
+    {{- if .Values.forge.fileStore.context }}
+    context:
+      type: {{ .Values.forge.fileStore.context.type }}
+      {{- if .Values.forge.fileStore.context.quota }}
+      quota: {{ .values.forge.fileStore.context.quota }}
+      {{- end }}
+      options:
+{{ toYaml .Values.forge.fileStore.context.options | indent 8 -}}
+    {{- end }}
 ---
 {{ if eq .Values.forge.fileStore.type "localfs" }}
 apiVersion: v1

--- a/helm/flowforge/templates/file-storage.yml
+++ b/helm/flowforge/templates/file-storage.yml
@@ -11,7 +11,7 @@ data:
     driver:
       type: {{ .Values.forge.fileStore.type }}
       {{- if .Values.forge.fileStore.quota }}
-      quota: {{ .values.forge.fileStore.quota }}
+      quota: {{ .Values.forge.fileStore.quota }}
       {{- end }}
       {{- if .Values.forge.fileStore.options }}
       options:
@@ -21,7 +21,7 @@ data:
     context:
       type: {{ .Values.forge.fileStore.context.type }}
       {{- if .Values.forge.fileStore.context.quota }}
-      quota: {{ .values.forge.fileStore.context.quota }}
+      quota: {{ .Values.forge.fileStore.context.quota }}
       {{- end }}
       options:
 {{ toYaml .Values.forge.fileStore.context.options | indent 8 -}}

--- a/helm/flowforge/templates/file-storage.yml
+++ b/helm/flowforge/templates/file-storage.yml
@@ -35,7 +35,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   accessModes:
-    - ReadWriteMany
+    - ReadWriteOnce
   resources:
     requests:
       storage: 10Gi

--- a/helm/flowforge/templates/job-upgrade-db.yaml
+++ b/helm/flowforge/templates/job-upgrade-db.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.forge.fileStore .Values.forge.localPostgresql -}}
+{{- if and .Values.forge.fileStore.context .Values.forge.localPostgresql -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,10 +9,9 @@ data:
     apk add --no-cache postgresql14-client
     psql -v ON_ERROR_STOP=1 -h flowforge-postgresql -U postgres postgres <<-ESQL
     SELECT datname FROM pg_database WHERE datistemplate = false;
-    -- CREATE DATABASE ff-context;
-    -- GRANT ALL PRIVILEGES ON DATABASE ff-context TO forge;
+    CREATE DATABASE "ff-context";
+    GRANT ALL PRIVILEGES ON DATABASE "ff-context" TO forge;
     ESQL
-    echo HelloWorld
 ---
 apiVersion: batch/v1
 kind: Job
@@ -20,7 +19,7 @@ metadata:
   name: flowforge-db-upgrade
   labels:
   annotations:
-    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook": post-upgrade,post-install
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
@@ -33,7 +32,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: add-context-db
-        image: "alpine"
+        image: "alpine:3.17.0"
         env:
         - name: PGPASSWORD
           valueFrom:

--- a/helm/flowforge/templates/job-upgrade-db.yaml
+++ b/helm/flowforge/templates/job-upgrade-db.yaml
@@ -1,0 +1,53 @@
+{{- if and .Values.forge.fileStore .Values.forge.localPostgresql -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: upgrade.sh
+data:
+  upgrade.sh: |
+    #!/bin/sh
+    apk add --no-cache postgresql14-client
+    psql -v ON_ERROR_STOP=1 -h flowforge-postgresql -U postgres postgres <<-ESQL
+    SELECT datname FROM pg_database WHERE datistemplate = false;
+    -- CREATE DATABASE ff-context;
+    -- GRANT ALL PRIVILEGES ON DATABASE ff-context TO forge;
+    ESQL
+    echo HelloWorld
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: flowforge-db-upgrade
+  labels:
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      name:
+      labels:
+        app: flowforge-file
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: add-context-db
+        image: "alpine"
+        env:
+        - name: PGPASSWORD
+          valueFrom:
+            secretKeyRef:
+                name: flowforge-postgresql
+                key: postgresql-postgres-password
+        volumeMounts:
+        - name: upgrade-script
+          mountPath: /usr/local
+        command:
+        - /bin/sh
+        - /usr/local/upgrade.sh
+      volumes:
+      - name: upgrade-script
+        configMap:
+          name: upgrade.sh
+{{- end -}}

--- a/helm/flowforge/templates/network-policy.yaml
+++ b/helm/flowforge/templates/network-policy.yaml
@@ -51,4 +51,7 @@ spec:
       - podSelector:
           matchLabels:
             app: flowforge
+      - podSelector:
+          matchLabels:
+            app: flowforge-file
 {{- end }}

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -240,6 +240,36 @@
                     
                 }
             },
+            "fileStore": {
+                "type": "object",
+                "properties": {
+                    "type": { 
+                        "type": "string"
+                    },
+                    "options": {
+                        "type": "object"
+                    },
+                    "context": {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string"
+                            },
+                            "options": {
+                                "type": "object"
+                            }
+                        },
+                        "required": [
+                            "type",
+                            "options"
+                        ]
+                    }
+                },
+                "required": [
+                    "type",
+                    "options"
+                ]
+            },
             "required": [
                 "domain",
                 "dbUsername",

--- a/helm/flowforge/values.yaml
+++ b/helm/flowforge/values.yaml
@@ -15,6 +15,19 @@ forge:
     enabled: false
   fileStore:
     enabled: false
+    type: localfs
+    quota: 104857600
+    options:
+      root: var/root
+    context:
+      type: sequelize
+      quota: 1048576
+      options:
+        type: postgres
+        host: flowforge-postgreql
+        username: forge
+        password: Zai1Wied
+        database: ff-context
 
 postgresql:
   postgresqlPostgresPassword: Moomiet0


### PR DESCRIPTION
Adds support for the persistent context to the helm chart

Includes a job to add the extra database to the locally provisioned instance of postgresql