### PR TITLE
Docker: Publish images for the device agent

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -184,7 +184,7 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           tags: |
-            type=semver,event=tag,pattern={{version}}-2.2.3
+            type=semver,event=tag,pattern={{version}}
           flavor: |
             latest=true
           images: |
@@ -206,7 +206,13 @@ jobs:
           platforms: linux/amd64, linux/arm64, linux/arm/v7 
           tags: ${{ steps.meta.outputs.tags }}
           push: true
-          
+      - name: Push README
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          repository: flowforge/device-agent
+          username: flowforge
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          readme-filepath: ./helm/flowforge-device-agent/README.md
 
   publish_helm:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -170,3 +170,39 @@ jobs:
           username: flowforge
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
           readme-filepath: ./helm/file-server/README.md
+
+
+  build_device_agent_container:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: 'flowforge/helm'
+          path: 'helm'
+      - name: Docker Meta Data
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          tags: |
+            type=semver,event=tag,pattern={{version}}-2.2.3
+          flavor: |
+            latest=false
+          images: |
+            flowforge/device-agent
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v1
+      - name: docker login
+        uses: docker/login-action@v1
+        with:
+          username: flowforge
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+      - name: Build and push FlowForge Application container
+        uses: docker/build-push-action@v2
+        with:
+          context: helm/flowforge-device-agent
+          file: helm/node-red-container/Dockerfile
+          platforms: linux/amd64, linux/arm64, linux/arm/v7 
+          tags: ${{ steps.meta.outputs.tags }}
+          push: true

--- a/flowforge-device-agent/Dockerfile
+++ b/flowforge-device-agent/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:16-alpine
+
+RUN mkdir /opt/flowforge-device
+RUN npm install -g @flowforge/flowforge-device-agent
+
+CMD ["flowforge-device-agent"]

--- a/flowforge-device-agent/README.md
+++ b/flowforge-device-agent/README.md
@@ -1,0 +1,11 @@
+# FlowForge Device Agent
+
+This container can be used to start a FlowForge device. The device needs to
+be [registered on your FlowForge instance](https://flowforge.com/docs/user/devices/#register-the-device).
+
+The YAML with configuration needs to be mounted inside the container.
+
+```
+docker run --mount /path/to/device.yml:/opt/flowforge-device/device.yml flowforge-device-agent:latest
+```
+


### PR DESCRIPTION
Like the other images, the device agent might be run in a container. This change makes it easier to achieve this for our customers.

- [ ] Needs updates on the main repository docs