### PR TITLE
No need to symlink python3 anymore

### DIFF
--- a/flowforge-container/Dockerfile
+++ b/flowforge-container/Dockerfile
@@ -7,7 +7,6 @@ RUN if [[ ! -z "$REGISTRY_TOKEN" ]]; then echo "//$REGISTRY/:_authToken=$REGISTR
 RUN if [[ ! -z "$REGISTRY" ]] ; then npm config set @flowforge:registry "https://$REGISTRY"; fi
 
 RUN apk add --no-cache --virtual build-base g++ make py3-pip sqlite-dev python3
-RUN ln -s `which python3` /usr/bin/python
 RUN npm config set python `which python3` --global
 
 WORKDIR /usr/src/forge


### PR DESCRIPTION
Alpine now sets /usr/bin/python to point to python3 so no need to do it ourselves 