### PR TITLE
Allow upgrade DB script to run without failing

### DIFF
--- a/helm/flowforge/templates/job-upgrade-db.yaml
+++ b/helm/flowforge/templates/job-upgrade-db.yaml
@@ -7,7 +7,7 @@ data:
   upgrade.sh: |
     #!/bin/sh
     apk add --no-cache postgresql14-client
-    psql -v  ON_ERROR_STOP=1 -h flowforge-postgresql -U postgres postgres <<-ESQL
+    psql -v ON_ERROR_STOP=1 -h flowforge-postgresql -U postgres postgres <<-ESQL
     SELECT datname FROM pg_database WHERE datistemplate = false;
     SELECT 'CREATE DATABASE "ff-context"' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'ff-context')\gexec
     GRANT ALL PRIVILEGES ON DATABASE "ff-context" TO "forge";

--- a/helm/flowforge/templates/job-upgrade-db.yaml
+++ b/helm/flowforge/templates/job-upgrade-db.yaml
@@ -7,9 +7,9 @@ data:
   upgrade.sh: |
     #!/bin/sh
     apk add --no-cache postgresql14-client
-    psql -h flowforge-postgresql -U postgres postgres <<-ESQL
+    psql -v  ON_ERROR_STOP=1 -h flowforge-postgresql -U postgres postgres <<-ESQL
     SELECT datname FROM pg_database WHERE datistemplate = false;
-    CREATE DATABASE "ff-context";
+    SELECT 'CREATE DATABASE "ff-context"' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'ff-context')\gexec
     GRANT ALL PRIVILEGES ON DATABASE "ff-context" TO "forge";
     ESQL
 ---

--- a/helm/flowforge/templates/job-upgrade-db.yaml
+++ b/helm/flowforge/templates/job-upgrade-db.yaml
@@ -7,10 +7,10 @@ data:
   upgrade.sh: |
     #!/bin/sh
     apk add --no-cache postgresql14-client
-    psql -v ON_ERROR_STOP=1 -h flowforge-postgresql -U postgres postgres <<-ESQL
+    psql -h flowforge-postgresql -U postgres postgres <<-ESQL
     SELECT datname FROM pg_database WHERE datistemplate = false;
     CREATE DATABASE "ff-context";
-    GRANT ALL PRIVILEGES ON DATABASE "ff-context" TO forge;
+    GRANT ALL PRIVILEGES ON DATABASE "ff-context" TO "forge";
     ESQL
 ---
 apiVersion: batch/v1


### PR DESCRIPTION
## Description

If helm upgrade was run twice this DB upgrade job would fail, while not a problem it left a old job in the pod list.

The script now tests if the database already exists before trying to create it.

## Related Issue(s)

This was raised in flowforge/flowforge#1524

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

