### PR TITLE
Bump 2.2.3 container to NodeJS 16 base

### DIFF
--- a/node-red-container/Dockerfile-2.2.x
+++ b/node-red-container/Dockerfile-2.2.x
@@ -1,4 +1,4 @@
-FROM nodered/node-red:2.2.3
+FROM nodered/node-red:2.2.3-16
 
 ARG REGISTRY
 ARG REGISTRY_TOKEN


### PR DESCRIPTION
## Description

The 2.2.3 based stacks are currently built on the default 2.2.3 container which is based on NodeJS 14.

The FlowForge Launcher now contains code that depends on NodeJS 16

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

