### PR TITLE
Wait for containers to build before publish helm

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -215,6 +215,7 @@ jobs:
           readme-filepath: ./helm/flowforge-device-agent/README.md
 
   publish_helm:
+    needs: [build_application_container, build_nodered_container, build_nodered_container_223, build_file_server_container, build_device_agent_container]
     runs-on: ubuntu-latest
     steps:
       - name: Install Helm


### PR DESCRIPTION
## Description

Prevents helm chart publish until all containers are built and published

