### PR TITLE
Fix missing `s` in default context host

### DIFF
--- a/helm/flowforge/values.yaml
+++ b/helm/flowforge/values.yaml
@@ -24,7 +24,7 @@ forge:
       quota: 1048576
       options:
         type: postgres
-        host: flowforge-postgreql
+        host: flowforge-postgresql
         username: forge
         password: Zai1Wied
         database: ff-context


### PR DESCRIPTION
## Description

Typo fix for default context db hostname

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 