### PR TITLE
Add posthog apihost to config

### DIFF
--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -63,8 +63,9 @@ To use STMP to send email
 
 Enables FlowForge Telemetry
 
- - `forge.telemetry.enabled` enables anonymized usage reporting (defaults `true`)
- - `forge.telemetry.posthog.apikey` enables posthog logging if set (no default)
+ - `forge.telemetry.enabled` enables anonymized usage reporting (default `true`)
+ - `forge.telemetry.posthog.apikey` enables posthog logging if set (not default)
+ - `forge.telemetry.posthog.apihost` sets posthog target host (required if apikey set)
  - `forge.telemetry.posthog.capture_pageview` (default `true`)
 
  ### Support

--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -65,7 +65,7 @@ Enables FlowForge Telemetry
 
  - `forge.telemetry.enabled` enables anonymized usage reporting (default `true`)
  - `forge.telemetry.posthog.apikey` enables posthog logging if set (not default)
- - `forge.telemetry.posthog.apihost` sets posthog target host (required if apikey set)
+ - `forge.telemetry.posthog.apiurl` sets posthog target host (required if apikey set)
  - `forge.telemetry.posthog.capture_pageview` (default `true`)
 
  ### Support

--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -65,7 +65,7 @@ Enables FlowForge Telemetry
 
  - `forge.telemetry.enabled` enables anonymized usage reporting (default `true`)
  - `forge.telemetry.posthog.apikey` enables posthog logging if set (not default)
- - `forge.telemetry.posthog.apiurl` sets posthog target host (required if apikey set)
+ - `forge.telemetry.posthog.apiurl` sets posthog target host (default `https://app.posthog.com`)
  - `forge.telemetry.posthog.capture_pageview` (default `true`)
 
  ### Support

--- a/helm/flowforge/templates/configmap.yaml
+++ b/helm/flowforge/templates/configmap.yaml
@@ -118,8 +118,9 @@ data:
         plausible:
           domain: {{ .Values.forge.telemetry.plausible }}
         {{ end -}}
-        {{ if .Values.forge.telemetry.posthog -}}
+        {{ if and (hasKey .Values.forge.telemetry "posthog") (hasKey .Values.forge.telemetry.posthog "apikey") -}}
         posthog:
+          apihost: {{ .Values.forge.telemetry.posthog.apihost }}
           apikey: {{ .Values.forge.telemetry.posthog.apikey}}
           {{ if hasKey .Values.forge.telemetry.posthog "capture_pageview" }}
           capture_pageview: {{ .Values.forge.telemetry.posthog.capture_pageview }}

--- a/helm/flowforge/templates/configmap.yaml
+++ b/helm/flowforge/templates/configmap.yaml
@@ -120,7 +120,9 @@ data:
         {{ end -}}
         {{ if and (hasKey .Values.forge.telemetry "posthog") (hasKey .Values.forge.telemetry.posthog "apikey") -}}
         posthog:
+          {{ if .Values.forge.telemetry.posthog.apiurl -}}
           apiurl: {{ .Values.forge.telemetry.posthog.apiurl }}
+          {{- end }}
           apikey: {{ .Values.forge.telemetry.posthog.apikey}}
           {{ if hasKey .Values.forge.telemetry.posthog "capture_pageview" }}
           capture_pageview: {{ .Values.forge.telemetry.posthog.capture_pageview }}

--- a/helm/flowforge/templates/configmap.yaml
+++ b/helm/flowforge/templates/configmap.yaml
@@ -120,7 +120,7 @@ data:
         {{ end -}}
         {{ if and (hasKey .Values.forge.telemetry "posthog") (hasKey .Values.forge.telemetry.posthog "apikey") -}}
         posthog:
-          apihost: {{ .Values.forge.telemetry.posthog.apihost }}
+          apiurl: {{ .Values.forge.telemetry.posthog.apiurl }}
           apikey: {{ .Values.forge.telemetry.posthog.apikey}}
           {{ if hasKey .Values.forge.telemetry.posthog "capture_pageview" }}
           capture_pageview: {{ .Values.forge.telemetry.posthog.capture_pageview }}

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -198,6 +198,9 @@
                         "posthog": {
                             "type": "object",
                             "properties": {
+                                "apihost":{
+                                    "type": "string"
+                                },
                                 "apikey": {
                                     "type": "string"
                                 },
@@ -206,6 +209,7 @@
                                 }
                             },
                             "required": [
+                                "apihost",
                                 "apikey"
                             ]
                         }

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -198,7 +198,7 @@
                         "posthog": {
                             "type": "object",
                             "properties": {
-                                "apihost":{
+                                "apiurl":{
                                     "type": "string"
                                 },
                                 "apikey": {
@@ -209,7 +209,7 @@
                                 }
                             },
                             "required": [
-                                "apihost",
+                                "apiurl",
                                 "apikey"
                             ]
                         }

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -209,7 +209,6 @@
                                 }
                             },
                             "required": [
-                                "apiurl",
                                 "apikey"
                             ]
                         }

--- a/test/customizations.yml
+++ b/test/customizations.yml
@@ -38,9 +38,10 @@ forge:
             userCost: 0
   telemetry:
     enabled: true
-    posthog:
+    posthog: 
       capture_pageview: false
       apikey: phc_fdlksajfdfadfsafsaf
+      apihost: app.posthog.com
   support:
     enabled: true
     hubspot: 12345678

--- a/test/customizations.yml
+++ b/test/customizations.yml
@@ -41,7 +41,6 @@ forge:
     posthog: 
       capture_pageview: false
       apikey: phc_fdlksajfdfadfsafsaf
-      apiurl: https://app.posthog.com
   support:
     enabled: true
     hubspot: 12345678

--- a/test/customizations.yml
+++ b/test/customizations.yml
@@ -41,7 +41,7 @@ forge:
     posthog: 
       capture_pageview: false
       apikey: phc_fdlksajfdfadfsafsaf
-      apihost: app.posthog.com
+      apiurl: https://app.posthog.com
   support:
     enabled: true
     hubspot: 12345678

--- a/test/unit/setup.js
+++ b/test/unit/setup.js
@@ -17,8 +17,8 @@ async function setup () {
     })
 
     const promise = new Promise((resolve, reject) => {
-        let stdout = ""
-        let stderr = ""
+        let stdout = ''
+        let stderr = ''
 
         child.stdout.on('data', data => {
             // console.log('out', data)
@@ -39,21 +39,14 @@ async function setup () {
                 const docs = documents.map(d => d.toJS())
                 resolve({
                     docs
-                }) 
-            } else {
-                reject({
-                    stderr,
-                    code
                 })
+            } else {
+                const err = new Error(stderr)
+                reject(err, code)
             }
-            
         })
     })
-
-    
-
     return promise
 }
-
 
 module.exports = setup


### PR DESCRIPTION
## Description

Adds configuration option for posthog host

## Related Issue(s)

#106 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [-] Changes `flowforge.yml`?
    - [-] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [-] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

