### PR TITLE
Fix line break in telemetry

### DIFF
--- a/helm/flowforge/templates/configmap.yaml
+++ b/helm/flowforge/templates/configmap.yaml
@@ -112,7 +112,7 @@ data:
       http: info
     telemetry:
       enabled: {{ .Values.forge.telemetry.enabled }}
-      {{- if or (.Values.forge.telemetry.plausible) (.Values.forge.telemetry.posthog) }}
+      {{ if or (.Values.forge.telemetry.plausible) (.Values.forge.telemetry.posthog) }}
       frontend:
         {{ if .Values.forge.telemetry.plausible -}}
         plausible:


### PR DESCRIPTION
## Description
extra `-` was removing all white space including line break

## Related Issue(s)

