### PR TITLE
Add device product/price to config map

### DIFF
--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -85,6 +85,8 @@ Enables FlowForge Telemetry
  - `forge.ee.billing.stripe.team_product` Stripe product id for default Team
  - `forge.ee.billing.stripe.project_price` Stripe price id for default Project Type
  - `forge.ee.billing.stripe.project_product` Stripe product id for default Project Type
+ - `forge.ee.billing.stripe.device_price` Stripe price id for Device (optional)
+ - `forge.ee.billing.stripe.device_product` Stripe product id for Device (optional)
  - `forge.ee.billing.stripe.new_customer_free_credit` Value in cents to be awarded as credit to new users
  - `forge.ee.billing.stripe.teams` a map containing Stripe Product & Price ids for named Team Types
 

--- a/helm/flowforge/templates/configmap.yaml
+++ b/helm/flowforge/templates/configmap.yaml
@@ -81,6 +81,12 @@ data:
         team_product: {{ .Values.forge.ee.billing.stripe.team_product }}
         project_price: {{ .Values.forge.ee.billing.stripe.project_price }}
         project_product: {{ .Values.forge.ee.billing.stripe.project_product }}
+        {{ if .Values.forge.ee.billing.stripe.device_price -}}
+        device_price: {{ .Values.forge.ee.billing.stripe.device_price }}
+        {{- end -}}
+        {{ if .Values.forge.ee.billing.stripe.device_product -}}
+        device_product: {{ .Values.forge.ee.billing.stripe.device_product }}
+        {{- end -}}
         {{ if .Values.forge.ee.billing.stripe.new_customer_free_credit -}}
         new_customer_free_credit: {{ .Values.forge.ee.billing.stripe.new_customer_free_credit | int }}
         {{- end -}}

--- a/helm/flowforge/templates/configmap.yaml
+++ b/helm/flowforge/templates/configmap.yaml
@@ -83,10 +83,10 @@ data:
         project_product: {{ .Values.forge.ee.billing.stripe.project_product }}
         {{ if .Values.forge.ee.billing.stripe.device_price -}}
         device_price: {{ .Values.forge.ee.billing.stripe.device_price }}
-        {{- end -}}
+        {{- end}}
         {{ if .Values.forge.ee.billing.stripe.device_product -}}
         device_product: {{ .Values.forge.ee.billing.stripe.device_product }}
-        {{- end -}}
+        {{- end}}
         {{ if .Values.forge.ee.billing.stripe.new_customer_free_credit -}}
         new_customer_free_credit: {{ .Values.forge.ee.billing.stripe.new_customer_free_credit | int }}
         {{- end -}}

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -143,6 +143,12 @@
                                         "project_product": {
                                             "type": "string"
                                         },
+                                        "device_price": {
+                                            "type": "string"
+                                        },
+                                        "device_product": {
+                                            "type": "string"
+                                        },
                                         "new_customer_free_credit": {
                                             "type": "integer"
                                         },

--- a/test/customizations.yml
+++ b/test/customizations.yml
@@ -30,6 +30,8 @@ forge:
         team_product: prod_123456
         project_price: price_1123456
         project_product: prod_123456
+        device_price: price_8888
+        device_product: prod_8888
         new_customer_free_credit: 1500
         teams:
           starter:


### PR DESCRIPTION
## Description

Adds `device_price` and `device_product` as *optional* config properties.

Ref: https://github.com/flowforge/admin/issues/145