### PR TITLE
Remove hard coded ingress annotations for AWS

### DIFF
--- a/helm/flowforge/templates/broker.yaml
+++ b/helm/flowforge/templates/broker.yaml
@@ -131,17 +131,6 @@ metadata:
   labels:
     app: flowforge-broker
   annotations:
-    {{- if .Values.forge.cloudProvider }}
-    {{- if eq .Values.forge.cloudProvider "aws" }}
-    kubernetes.io/ingress.class: alb
-    alb.ingress.kubernetes.io/scheme: internet-facing
-    alb.ingress.kubernetes.io/target-type: ip
-    alb.ingress.kubernetes.io/group.name: flowforge
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}, {"HTTP":80}]'
-    alb.ingress.kubernetes.io/ssl-redirect: '443'
-    abl.ingress.kubernetes.io/healthcheck-path: '/ping.html'
-    {{- end }}
-    {{- end }}
 spec:
   rules:
     - host: mqtt.{{ .Values.forge.domain }}

--- a/helm/flowforge/templates/service-ingress.yaml
+++ b/helm/flowforge/templates/service-ingress.yaml
@@ -15,16 +15,6 @@ kind: Ingress
 metadata:
   name: flowforge-ingress
   annotations:
-    {{- if .Values.forge.cloudProvider }}
-    {{- if eq .Values.forge.cloudProvider "aws" }}
-    kubernetes.io/ingress.class: alb
-    alb.ingress.kubernetes.io/scheme: internet-facing
-    alb.ingress.kubernetes.io/target-type: ip
-    alb.ingress.kubernetes.io/group.name: flowforge
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}, {"HTTP":80}]'
-    alb.ingress.kubernetes.io/ssl-redirect: '443'
-    {{- end }}
-    {{- end }}
 spec:
   rules:
   {{- if .Values.forge.entryPoint }}


### PR DESCRIPTION
## Description

While deploying to production I noticed that these were still present and no longer required.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

