### PR TITLE
Resync maintenance branch on release

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -241,4 +241,12 @@ jobs:
           git add .
           git -c user.name='FlowForge Build Bot' -c user.email='noreply@flowforge.com' commit -m "Add ${{ github.ref_name }} helm chart"
           git push origin
+      - name: Resync Maintenance
+        if: ${{ endsWith(github.ref, '.0') }}
+        run: |
+          git checkout maintenance
+          git reset --hard origin/main
+          git push --force origin maintenance
+
+
 

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -244,6 +244,7 @@ jobs:
       - name: Resync Maintenance
         if: ${{ endsWith(github.ref, '.0') }}
         run: |
+          cd helm
           git checkout maintenance
           git reset --hard origin/main
           git push --force origin maintenance


### PR DESCRIPTION
## Description

Syncs the maintenance branch to match main on a minor release (x.y.0)

## Related Issue(s)

NA

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

