### PR TITLE
Fix Release.Name in job-upgrade-db

### DIFF
--- a/helm/flowforge/templates/job-upgrade-db.yaml
+++ b/helm/flowforge/templates/job-upgrade-db.yaml
@@ -7,7 +7,7 @@ data:
   upgrade.sh: |
     #!/bin/sh
     apk add --no-cache postgresql14-client
-    psql -v ON_ERROR_STOP=1 -h flowforge-postgresql -U postgres postgres <<-ESQL
+    psql -v ON_ERROR_STOP=1 -h {{ .Release.Name }}-postgresql -U postgres postgres <<-ESQL
     SELECT datname FROM pg_database WHERE datistemplate = false;
     SELECT 'CREATE DATABASE "ff-context"' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'ff-context')\gexec
     GRANT ALL PRIVILEGES ON DATABASE "ff-context" TO "forge";
@@ -16,7 +16,7 @@ data:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: flowforge-db-upgrade
+  name: {{ .Release.Name }}-db-upgrade
   labels:
   annotations:
     "helm.sh/hook": post-upgrade,post-install
@@ -37,7 +37,7 @@ spec:
         - name: PGPASSWORD
           valueFrom:
             secretKeyRef:
-                name: flowforge-postgresql
+                name: {{ .Release.Name }}-postgresql
                 key: postgresql-postgres-password
         volumeMounts:
         - name: upgrade-script


### PR DESCRIPTION
## Description

With a name of release different from _flowforge_ the job _xxx-db-upgrade_ can't find _xxx-configMap_ and loop with fails
This PR try to fix it

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [x] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

