### PR TITLE
Add HOME env var

### DIFF
--- a/node-red-container/Dockerfile
+++ b/node-red-container/Dockerfile
@@ -21,6 +21,7 @@ USER node-red
 RUN npm install @flowforge/nr-launcher@${BUILD_TAG}
 
 ENV NODE_PATH=/usr/src/node-red
+ENV HOME=/usr/src/node-red
 
 EXPOSE 2880
 

--- a/node-red-container/Dockerfile-2.2.x
+++ b/node-red-container/Dockerfile-2.2.x
@@ -21,6 +21,7 @@ USER node-red
 RUN npm install @flowforge/nr-launcher@${BUILD_TAG}
 
 ENV NODE_PATH=/usr/src/node-red
+ENV HOME=/usr/src/node-red
 
 EXPOSE 2880
 

--- a/node-red-container/Dockerfile-3.1
+++ b/node-red-container/Dockerfile-3.1
@@ -21,6 +21,7 @@ USER node-red
 RUN npm install @flowforge/nr-launcher@${BUILD_TAG}
 
 ENV NODE_PATH=/usr/src/node-red
+ENV HOME=/usr/src/node-red
 
 EXPOSE 2880
 


### PR DESCRIPTION
## Description
Some nodes require the HOME env var to be set, this ensures it's always set in the container

Opted for /usr/src/node-red as that matches the entry in the /etc/passwd file.

## Related Issue(s)

Discovered via a HubSpot Ticket

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

