### PR TITLE
Add deviceCost to configmap

### DIFF
--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -87,6 +87,7 @@ Enables FlowForge Telemetry
  - `forge.ee.billing.stripe.project_product` Stripe product id for default Project Type
  - `forge.ee.billing.stripe.device_price` Stripe price id for Device (optional)
  - `forge.ee.billing.stripe.device_product` Stripe product id for Device (optional)
+ - `forge.ee.billing.stripe.deviceCost` Set the displayed price for a Device (optional)
  - `forge.ee.billing.stripe.new_customer_free_credit` Value in cents to be awarded as credit to new users
  - `forge.ee.billing.stripe.teams` a map containing Stripe Product & Price ids for named Team Types
 

--- a/helm/flowforge/templates/configmap.yaml
+++ b/helm/flowforge/templates/configmap.yaml
@@ -92,6 +92,9 @@ data:
         {{ if .Values.forge.ee.billing.stripe.device_product -}}
         device_product: {{ .Values.forge.ee.billing.stripe.device_product }}
         {{- end}}
+        {{ if .Values.forge.ee.billing.stripe.deviceCost -}}
+        deviceCost: {{ .Values.forge.ee.billing.stripe.deviceCost }}
+        {{- end}}
         {{ if .Values.forge.ee.billing.stripe.new_customer_free_credit -}}
         new_customer_free_credit: {{ .Values.forge.ee.billing.stripe.new_customer_free_credit | int }}
         {{- end -}}


### PR DESCRIPTION
## Description

Allow `forge.ee.billing.stripe.deviceCost` to be set from the helm chart

## Related Issue(s)



## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

