### PR TITLE
Ingress settings for Flowforge in K8s

### DIFF
--- a/helm/flowforge/templates/deployment.yaml
+++ b/helm/flowforge/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
         {{- end }}
         ports:
         - containerPort: 3000
-        securityContext: 
+        securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
       {{- if .Values.forge.registrySecrets }}

--- a/helm/flowforge/templates/service-ingress.yaml
+++ b/helm/flowforge/templates/service-ingress.yaml
@@ -15,7 +15,13 @@ kind: Ingress
 metadata:
   name: flowforge-ingress
   annotations:
+  {{- if .Values.ingress.annotations }}
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+  {{- end }}
 spec:
+  {{- if and $.Values.ingress.className (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ $.Values.ingress.className }}
+  {{- end }}
   rules:
   {{- if .Values.forge.entryPoint }}
   - host: {{ .Values.forge.entryPoint }}

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -248,8 +248,8 @@
                             "type",
                             "options"
                         ]
-                    } 
-                    
+                    }
+
                 },
                 "support": {
                     "type": "object",
@@ -294,6 +294,18 @@
                 "required": [
                     "postgres"
                 ]
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "minProperties": 0
+                },
+                "className": {
+                    "type": "string"
+                }
             }
         }
     },

--- a/helm/flowforge/values.yaml
+++ b/helm/flowforge/values.yaml
@@ -1,4 +1,7 @@
 forge:
+  domain: "TO FILL"
+  entryPoint: "TO FILL"
+  registry: "TO FILL"
   dbUsername: forge
   dbPassword: Zai1Wied
   dbName: flowforge
@@ -38,5 +41,5 @@ postgresql:
   postgresqlDatabase: flowforge
 
 ingress:
-  annotations: ""
+  annotations: {}
   className: ""

--- a/helm/flowforge/values.yaml
+++ b/helm/flowforge/values.yaml
@@ -1,7 +1,4 @@
 forge:
-  domain: "TO FILL"
-  entryPoint: "TO FILL"
-  registry: "TO FILL"
   dbUsername: forge
   dbPassword: Zai1Wied
   dbName: flowforge

--- a/helm/flowforge/values.yaml
+++ b/helm/flowforge/values.yaml
@@ -36,4 +36,7 @@ postgresql:
   postgresqlUsername: forge
   postgresqlPassword: Zai1Wied
   postgresqlDatabase: flowforge
-  
+
+ingress:
+  annotations: ""
+  className: ""


### PR DESCRIPTION
## Description

We tried to deploy flowforge on AWS and Azure K8s cluster, and found that on both platforms it requires custom annotations to work with vendor Ingress controllers. 

This PR:

* Adds ability to set platform specific `Ingress` settings
* Documents new values in schema
* Adds dummy values to `values.yaml` to make the file formally valid against the schema

All changes are backward compatible

- [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label