### PR TITLE
device-agent: helm chart for deployment in kubernetes

### DIFF
--- a/flowforge-device-helm/.gitignore
+++ b/flowforge-device-helm/.gitignore
@@ -1,0 +1,1 @@
+device.yml

--- a/flowforge-device-helm/.helmignore
+++ b/flowforge-device-helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/flowforge-device-helm/Chart.yaml
+++ b/flowforge-device-helm/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: flowforge-device
+description: Helm chart which deploys FlowForge devices in Kubernetes cluster
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.0.1"

--- a/flowforge-device-helm/Makefile
+++ b/flowforge-device-helm/Makefile
@@ -1,0 +1,35 @@
+.PHONY: install upgrade uninstall
+
+NAMESPACE ?= devices
+
+DEV_FILE ?= device.yml
+
+install-azure upgrade-azure template-azure: $(DEV_FILE)
+	helm $(subst -azure,,$@) \
+		flowforge-device \
+		. \
+		--values values-azure.yaml \
+		--set provisioningToken=$(shell base64 -i $(DEV_FILE)) \
+		--create-namespace \
+		--namespace=$(NAMESPACE)
+
+install-aws upgrade-aws template-aws: $(DEV_FILE)
+	helm $(subst -aws,,$@) \
+		flowforge-device \
+		. \
+		--values values-aws.yaml \
+		--set provisioningToken=$(shell base64 -i $(DEV_FILE)) \
+		--create-namespace \
+		--namespace=$(NAMESPACE)
+
+uninstall:
+	helm $@ \
+		flowforge-device
+
+template-debug-azure: device.yml
+	helm template \
+		flowforge-device \
+		. \
+		--values values-azure.yaml \
+		--set provisioningToken=$(shell base64 -i $(DEV_FILE)) \
+		--debug

--- a/flowforge-device-helm/README.md
+++ b/flowforge-device-helm/README.md
@@ -1,0 +1,36 @@
+# Helm chart for FlowForge device in Kubernetes
+
+This chart deploys FlowForge devices to a Kubernetes cluster. Devices can be assigned to a team or to a project during deployment.
+
+Device instances are deployed as `Pods` in a `StatefulSet`. Every pod has own storage volume to keep variable data.
+
+### Device installation
+
+The procedure has been tested for Azure and AWS Kubernetes services.
+
+1. Get provisioning token. In FlowForge Web-UI go to `Team` -> `Settings` -> `Devices` -> `Add Token` and save a token.
+2. Save provisioning token to a file `device.yml` in the current (README.md) directory
+3. Install `make` utility.
+4. Make sure you have `base64` utility. Should be available on any Linux or MacOSX system.
+5. Configure `kubectl` to access target K8S cluster with `default` context.
+6. Edit `values-aws.yaml` or `values-azure.yaml` files. Fill with your custom settings.
+7. Install the chart with command `make install-aws` or `make install-azure`. To choose namespace and device file name use command `make install-aws NAMESPACE=team-b DEV_FILE=device.yml`
+8. Verify if pods are running in `devices` namespace.
+9. Verify if devices are visible on FlowForge Web-UI.
+
+### Upgrade after HELM modifications
+`make upgrade-{vendor}`
+
+### Uninstall the chart
+`make uninstall`
+
+Note that persistent volume claims and volumes will remain existing.
+
+### Token update procedure
+
+In case if device token has been updated, it is not enough just update the Helm.
+
+1. Uninstall Helm chart
+2. Manually remove `PersistenVolumeClaims`  `flowforge-data-flowforge-device-*`.
+3. Manually remove related `PersistenVolumes`
+4. Install the chart with new device token.

--- a/flowforge-device-helm/templates/NOTES.txt
+++ b/flowforge-device-helm/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "flowforge-device.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "flowforge-device.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "flowforge-device.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "flowforge-device.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/flowforge-device-helm/templates/_helpers.tpl
+++ b/flowforge-device-helm/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "flowforge-device.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "flowforge-device.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "flowforge-device.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "flowforge-device.labels" -}}
+helm.sh/chart: {{ include "flowforge-device.chart" . }}
+{{ include "flowforge-device.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "flowforge-device.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "flowforge-device.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "flowforge-device.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "flowforge-device.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/flowforge-device-helm/templates/hpa.yaml
+++ b/flowforge-device-helm/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "flowforge-device.fullname" . }}
+  labels:
+    {{- include "flowforge-device.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "flowforge-device.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/flowforge-device-helm/templates/ingress.yaml
+++ b/flowforge-device-helm/templates/ingress.yaml
@@ -1,0 +1,75 @@
+{{- $replicaCount := .Values.replicaCount | int -}}
+
+
+{{- if $.Values.ingress.enabled -}}
+
+  {{- $fullName := include "flowforge-device.fullname" . -}}
+  {{- $svcPort := .Values.service.port -}}
+  {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+    {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+    {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+    {{- end }}
+  {{- end }}
+
+{{- $context := . -}}
+
+{{- range $index := until $replicaCount -}}
+
+{{- if semverCompare ">=1.19-0" $context.Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" $context.Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-{{ $index }}
+  labels:
+    {{- include "flowforge-device.labels" $context | nindent 4 }}
+  {{- with $context.Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and $context.Values.ingress.className (semverCompare ">=1.18-0" $context.Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ $context.Values.ingress.className }}
+  {{- end }}
+  {{- if $context.Values.ingress.tls }}
+  tls:
+    {{- range $context.Values.ingress.tls }}
+    - hosts:
+      {{- range $context.Values.ingress.hosts }}
+        - ff-device-{{ $index }}.{{ .host }}
+      {{- end }}
+      secretName: ff-device-{{ $index }}.{{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range $context.Values.ingress.hosts }}
+    # - host: {{ .host }}
+    - host: ff-device-{{ $index }}.{{ .host }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+          # - path: {{ .path }}ff-device-{{ $index }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $context.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $context.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}-{{ $index }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}-{{ $index }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+
+---
+{{- end }}
+{{- end }}

--- a/flowforge-device-helm/templates/secret.yaml
+++ b/flowforge-device-helm/templates/secret.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: provisioning-token
+data:
+  device.yml: {{ .Values.provisioningToken }}

--- a/flowforge-device-helm/templates/service.yaml
+++ b/flowforge-device-helm/templates/service.yaml
@@ -1,0 +1,24 @@
+{{- $replicaCount := .Values.replicaCount | int -}}
+
+{{- $context := . -}}
+
+{{- range $index := until $replicaCount -}}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "flowforge-device.fullname" $context }}-{{ $index }}
+  labels:
+    {{- include "flowforge-device.labels" $context | nindent 4 }}
+spec:
+  type: {{ $context.Values.service.type }}
+  ports:
+    - port: {{ $context.Values.service.port }}
+      targetPort: {{ $context.Values.service.port }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "flowforge-device.selectorLabels" $context | nindent 4 }}
+    statefulset.kubernetes.io/pod-name: flowforge-device-{{ $index }}
+---
+{{- end }}

--- a/flowforge-device-helm/templates/serviceaccount.yaml
+++ b/flowforge-device-helm/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "flowforge-device.serviceAccountName" . }}
+  labels:
+    {{- include "flowforge-device.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/flowforge-device-helm/templates/statefulset.yaml
+++ b/flowforge-device-helm/templates/statefulset.yaml
@@ -1,0 +1,150 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "flowforge-device.fullname" . }}
+  labels:
+    {{- include "flowforge-device.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  serviceName: {{ include "flowforge-device.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "flowforge-device.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "flowforge-device.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "flowforge-device.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+        - name: provisioning-token
+          secret:
+            secretName: provisioning-token
+        - name: nginx-config
+          configMap:
+            name: nginx-config-map
+            items:
+              - key: nginx.conf
+                path: nginx.conf
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["sh", "-c", "if [ ! -f /opt/flowforge-device/device.yml ]; then cp /etc/flowforge-token/device.yml /opt/flowforge-device/device.yml; fi && flowforge-device-agent --config /opt/flowforge-device/device.yml --port 1880"]
+          # livenessProbe:
+            # exec:
+            #   command:
+            #     - "true"
+            # httpGet:
+            #   path: /health
+            #   port: http
+          # readinessProbe:
+            # exec:
+            #   command:
+            #     - "true"
+            # httpGet:
+            #   path: /health
+            #   port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+          - name: provisioning-token
+            readOnly: true
+            mountPath: "/etc/flowforge-token"
+          - name: flowforge-data
+            readOnly: false
+            mountPath: "/opt/flowforge-device"
+        - name: nginx-healthcheck-proxy
+          image: nginx
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+  volumeClaimTemplates:
+  - metadata:
+      name: flowforge-data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 1Gi
+      {{- if .Values.storageClass }}
+      storageClassName: {{ .Values.storageClass }}
+      {{- end }}
+
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config-map
+data:
+  nginx.conf: |
+    worker_processes auto;
+    error_log /var/log/nginx/error.log;
+
+    events {
+        worker_connections 1024;
+    }
+
+    http {
+        upstream flowforge_device {
+            server 127.0.0.1:1880;
+        }
+
+        server {
+            listen 80;
+
+            location /health {
+                return 200 "OK";
+            }
+
+            location / {
+                proxy_pass http://flowforge_device;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            }
+        }
+    }

--- a/flowforge-device-helm/templates/tests/test-connection.yaml
+++ b/flowforge-device-helm/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "flowforge-device.fullname" . }}-test-connection"
+  labels:
+    {{- include "flowforge-device.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "flowforge-device.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/flowforge-device-helm/values-aws.yaml
+++ b/flowforge-device-helm/values-aws.yaml
@@ -1,0 +1,95 @@
+# Default values for flowforge-device.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 3
+
+image:
+  repository: flowforge/device-agent
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: true
+  className: "alb"
+  annotations:
+    alb.ingress.kubernetes.io/actions.ssl-redirect: >-
+      {"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port":
+      "443", "StatusCode": "HTTP_301"}}
+    alb.ingress.kubernetes.io/certificate-arn: "TODO fill the value here"
+    alb.ingress.kubernetes.io/group.name: platform-base
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-Ext-2018-06
+    alb.ingress.kubernetes.io/target-type: ip
+  hosts:
+    - host: "TOOD fill the value here"
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+        - path: /*
+          pathType: ImplementationSpecific
+  tls: []
+  # - secretName: azure-dev.aiolaadvisor.com-ingress-tls
+    # hosts:
+    #   - "*.flowforge.azure-dev.aiolaadvisor.com"
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+provisioningToken: ""
+
+storageClass: ""

--- a/flowforge-device-helm/values-azure.yaml
+++ b/flowforge-device-helm/values-azure.yaml
@@ -1,0 +1,85 @@
+# Default values for flowforge-device.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 3
+
+image:
+  repository: flowforge/device-agent
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: true
+  className: "azure-application-gateway"
+  annotations:
+    ingressClassName: azure/application-gateway
+  hosts:
+    - host: "TODO set host here"
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+        - path: /*
+          pathType: ImplementationSpecific
+  tls:
+  - secretName: "TODO set value here"
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+provisioningToken: ""
+
+storageClass: ""


### PR DESCRIPTION
## Description

Despite device agents were designed for hardware devices, there are useful real life scenarios to run flow instances on Kubernetes. i.e. 
* for flowforge development purposes
* to scale running flow
* to achieve high availability with multiple running flow instances
* to have more flexibility in running flow instance configuration, than FlowForge UI supports (custom Ingress settings, service accounts, scaling, secrets and configuration maps, ...)

The Helm was tested on Azure and AWS K8S, therefore providing custom `values.yaml` for this vendors which can be used with slight edits.

## Related Issue(s)

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
    - [x] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

