### PR TITLE
FlowForge helm: 1. Editors: service account. 2. Broker: propagate ingress. 3. README

### DIFF
--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -32,6 +32,7 @@ If using an external PostgreSQL Database you will need to create the database an
  - `forge.localPostrgresql` Deploy a PostgreSQL v14 Database into Kubernetes cluster (default `true`)
  - `forge.postgres.host` the hostname of an external PostgreSQL database (default not set)
  - `forge.postgres.port` the port of an external PostgreSQL database (default `5432`)
+ - `forge.postgres.ssl` sets the connection to the database to use SSL/TLS (default `false`)
  - `forge.cloudProvider` currently only accepts `aws` but will include more as needed (default not set)
  - `forge.projectSelector` a collection of labels and values to filter nodes that Project Pods will run on (default `role: projects`)
  - `forge.managementSelector` a collection of labels and values to filter nodes the Forge App will run on (default `role: management`)

--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -121,3 +121,20 @@ Enables FlowForge Telemetry
  ### Ingress
  - `ingress.annotations` ingress annotations (default is `{}`). This value is also applied to Editor instances created by FlowForge.
  - `ingress.className` ingress class name (default is `"""`). This value is also applied to Editor instances created by FlowForge. 
+
+### Editors IAM
+   Provision default service account for Editors if `editors.serviceAccount.create` is `true`.
+
+- `editors.serviceAccount.create` flag, indicates whether default Editors service account is going to be provisioned.
+- `editors.serviceAccount.annotations` k8s service account annotations.
+- `editors.serviceAccount.name` name of the service account for Editors.
+
+Example for <i>AWS</i>:
+```yaml
+editors:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}
+    create: true
+    name: editors
+```

--- a/helm/flowforge/templates/broker.yaml
+++ b/helm/flowforge/templates/broker.yaml
@@ -131,7 +131,13 @@ metadata:
   labels:
     app: flowforge-broker
   annotations:
+  {{- if .Values.ingress.annotations }}
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+  {{- end }}
 spec:
+  {{- if $.Values.ingress.className }}
+  ingressClassName: {{ $.Values.ingress.className }}
+  {{- end }}
   rules:
     - host: mqtt.{{ .Values.forge.domain }}
       http:

--- a/helm/flowforge/templates/configmap.yaml
+++ b/helm/flowforge/templates/configmap.yaml
@@ -25,6 +25,9 @@ data:
       user: {{ .Values.forge.dbUsername }}
       password: {{ .Values.forge.dbPassword }}
       db: {{ .Values.forge.dbName }}
+      {{- if and (hasKey .Values.forge "postgres") (hasKey .Values.forge.postgres "ssl") }}
+      ssl: {{ .Values.forge.postgres.ssl }}
+      {{- end }}
     driver:
       type: kubernetes
       options:

--- a/helm/flowforge/templates/deployment.yaml
+++ b/helm/flowforge/templates/deployment.yaml
@@ -36,6 +36,10 @@ spec:
         - name: INGRESS_CLASS_NAME
           value: {{ .Values.ingress.className }}
         {{- end }}
+        {{- if .Values.editors.serviceAccount }}
+        - name: EDITOR_SERVICE_ACCOUNT
+          value: {{ .Values.editors.serviceAccount.name }}
+        {{- end }}
         {{- if .Values.forge.projectDeploymentTolerations }}
         - name: DEPLOYMENT_TOLERATIONS
           value: {{ .Values.forge.projectDeploymentTolerations | toJson | quote }}

--- a/helm/flowforge/templates/service-account.yaml
+++ b/helm/flowforge/templates/service-account.yaml
@@ -9,11 +9,27 @@ metadata:
     eks.amazonaws.com/sts-regional-endpoints: "true"
   {{- end }}
   {{- end }}
+
+
+{{- if .Values.editors.serviceAccount.create }}
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.editors.serviceAccount.name }}
+  namespace: {{ .Values.forge.projectNamespace }}
+  {{- with .Values.editors.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
+
+---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: create-pod
+  name: {{ .Release.Name }}-create-pod
 rules:
 - apiGroups: [""]
   resources: ["pods", "pods/log", "pods/exec", "pods/status"]
@@ -45,5 +61,5 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: create-pod
+  name: {{ .Release.Name }}-create-pod
   apiGroup: rbac.authorization.k8s.io

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -101,6 +101,9 @@
                         },
                         "port": {
                             "type": "integer"
+                        },
+                        "ssl": {
+                            "type": "boolean"
                         }
                     },
                     "required": [

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -309,6 +309,32 @@
                     "type": "string"
                 }
             }
+        },
+        "editors": {
+            "type": "object",
+            "properties": {
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "minProperties": 1,
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        },
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name of service account (scope of uniqueness is a 'Projects' namespace)"
+                        }
+                    },
+                    "required": ["annotations", "name"]
+                }
+            },
+            "required": ["serviceAccount"]
         }
     },
     "required": [

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -318,10 +318,7 @@
                     "properties": {
                         "annotations": {
                             "type": "object",
-                            "minProperties": 1,
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "minProperties": 0
                         },
                         "create": {
                             "type": "boolean"

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -116,6 +116,28 @@
                 "projectSelector": {
                     "type": "object"
                 },
+                "projectDeploymentTolerations": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "effect": {
+                                "type": "string"
+                            },
+                            "key": {
+                                "type": "string"
+                            },
+                            "operator": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["effect", "key", "operator", "value"]
+                    },
+                    "default": []
+                },
                 "managementSelector": {
                     "type": "object"
                 },

--- a/helm/flowforge/values.yaml
+++ b/helm/flowforge/values.yaml
@@ -59,4 +59,3 @@ editors:
     create: true
     annotations: {}
     name: editors
-    namespace:

--- a/helm/flowforge/values.yaml
+++ b/helm/flowforge/values.yaml
@@ -1,6 +1,6 @@
 forge:
   dbUsername: forge
-  dbPassword: ""
+  dbPassword: Zai1Wied
   dbName: flowforge
   localPostgresql: true
   https: true
@@ -39,14 +39,14 @@ forge:
   domain: ""
   entryPoint: ""
   environment: {}
-  image: 355908013639.dkr.ecr.eu-west-1.amazonaws.com/flowforge/forge-k8s:1.5.0
-  registry: 355908013639.dkr.ecr.eu-west-1.amazonaws.com
+  image: ""
+  registry: ""
 
 postgresql:
-  postgresqlDatabase: flowforge
-  postgresqlPassword: ""
-  postgresqlPostgresPassword: ""
+  postgresqlPostgresPassword: Moomiet0
   postgresqlUsername: forge
+  postgresqlPassword: Zai1Wied
+  postgresqlDatabase: flowforge
   global:
     storageClass: default
 

--- a/helm/flowforge/values.yaml
+++ b/helm/flowforge/values.yaml
@@ -1,18 +1,17 @@
 forge:
   dbUsername: forge
-  dbPassword: Zai1Wied
+  dbPassword: ""
   dbName: flowforge
   localPostgresql: true
   https: true
   projectNamespace: flowforge
   projectSelector:
     role: projects
-
   projectDeploymentTolerations: []
-#    - key: purpose
-#      operator: Equal
-#      value: flowforge-projects
-#      effect: NoSchedule
+  #    - key: purpose
+  #      operator: Equal
+  #      value: flowforge-projects
+  #      effect: NoSchedule
   managementSelector:
     role: management
   telemetry:
@@ -32,17 +31,32 @@ forge:
         type: postgres
         host: flowforge-postgresql
         username: forge
-        password: Zai1Wied
+        password: ""
         database: ff-context
   support:
     enabled: false
 
+  domain: ""
+  entryPoint: ""
+  environment: {}
+  image: 355908013639.dkr.ecr.eu-west-1.amazonaws.com/flowforge/forge-k8s:1.5.0
+  registry: 355908013639.dkr.ecr.eu-west-1.amazonaws.com
+
 postgresql:
-  postgresqlPostgresPassword: Moomiet0
-  postgresqlUsername: forge
-  postgresqlPassword: Zai1Wied
   postgresqlDatabase: flowforge
+  postgresqlPassword: ""
+  postgresqlPostgresPassword: ""
+  postgresqlUsername: forge
+  global:
+    storageClass: default
 
 ingress:
   annotations: {}
   className: ""
+
+editors:
+  serviceAccount:
+    create: true
+    annotations: {}
+    name: editors
+    namespace:


### PR DESCRIPTION
Multiple changes in FlowForge helm, all are optional.

## Description

FlowForge helm edits: 
1. **Editors**: optional service account provisioning*. 
2. **Broker**: propagate ingress definitions to broker helm. 
3. **values.yaml**: remove secrets from referent `values.yaml`, adding ref for `Editors default service account definition`. 
4. **README.md**: update with IAM section.

*Note that by "default" here meant that all Editor instances will be provisioned with this service account linked.
> We have a need and the plan for multiple IAM support, per Project, as a part of Project Configuration with the ability to change IAM binding (likewise the stack can be changed).

## Related Issue(s)

[FlowForge helm: option to provision default service account for editors. broker: derive the ingress definitions from values.yaml. cluster role-related: resources names should be release-dependent](https://github.com/flowforge/helm/issues/147)

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

