### PR TITLE
Revert create-pod Role name

### DIFF
--- a/helm/flowforge/templates/service-account.yaml
+++ b/helm/flowforge/templates/service-account.yaml
@@ -29,7 +29,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Release.Name }}-create-pod
+  name: create-pod
 rules:
 - apiGroups: [""]
   resources: ["pods", "pods/log", "pods/exec", "pods/status"]
@@ -61,5 +61,5 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Release.Name }}-create-pod
+  name: create-pod
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
@elenaviter I've had to revert the renaming of the ClusterRole because it breaks upgrades.

We can look at this again after the release this week

## Description

<!-- Describe your changes in detail -->
We can not change the name of an already created ClusterRole as it breaks upgrades.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

