### PR TITLE
Disable production containers build

### DIFF
--- a/.github/workflows/fileserver-container.yml
+++ b/.github/workflows/fileserver-container.yml
@@ -35,6 +35,7 @@ jobs:
   
   build-prod:
     name: Build production image
+    if: false
     uses: flowforge/github-actions-workflows/.github/workflows/build_container_image.yml@main
     with:
       environment: 'production'

--- a/.github/workflows/flowforge-container.yml
+++ b/.github/workflows/flowforge-container.yml
@@ -37,6 +37,7 @@ jobs:
   
   build-prod:
     name: Build production image
+    if: false
     uses: flowforge/github-actions-workflows/.github/workflows/build_container_image.yml@main
     with:
       environment: 'production'


### PR DESCRIPTION
## Description

Disable production container images build due to:
* we do not do automatic production deployments atm
* github does not allow to set custom timeout for deployment approvals for a particular environment (default: 30 days)
* we do not want to manually reject production deployments

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

