### PR TITLE
Add Node-RED 3.1.0 containers

### DIFF
--- a/.github/workflows/nodered-container.yml
+++ b/.github/workflows/nodered-container.yml
@@ -17,11 +17,12 @@ on:
       - main
 
 jobs:
-  build-stage:
+  build-stage-302:
     uses: flowforge/github-actions-workflows/.github/workflows/build_container_image.yml@main
     with:
       environment: 'stage'
       image_name: 'node-red'
+      dockerfile_path: Dockerfile
       package_dependencies: |
         @flowforge/nr-project-nodes
       build_context: 'node-red-container'
@@ -36,6 +37,7 @@ jobs:
       environment: 'stage'
       image_name: 'node-red'
       image_tag_prefix: '2.2.3-'
+      dockerfile_path: Dockerfile-2.2.x
       package_dependencies: |
         @flowforge/nr-project-nodes
       build_context: 'node-red-container'
@@ -44,4 +46,18 @@ jobs:
       npm_registry_auth_token: ${{ secrets.GITHUB_TOKEN }}
       aws_access_key_id: ${{ secrets.STAGING_AWS_ID }}
       aws_access_key_secret: ${{ secrets.STAGING_AWS_KEY }}
-  
+  build-stage-310:
+    uses: flowforge/github-actions-workflows/.github/workflows/build_container_image.yml@main
+    with:
+      environment: 'stage'
+      image_name: 'node-red'
+      image_tag_prefix: '3.1.0-'
+      dockerfile_path: Dockerfile-3.1
+      package_dependencies: |
+        @flowforge/nr-project-nodes
+      build_context: 'node-red-container'
+      npm_registry_url: ${{ vars.PRIVATE_NPM_REGISTRY_URL }}
+    secrets:
+      npm_registry_auth_token: ${{ secrets.GITHUB_TOKEN }}
+      aws_access_key_id: ${{ secrets.STAGING_AWS_ID }}
+      aws_access_key_secret: ${{ secrets.STAGING_AWS_KEY }}

--- a/node-red-container/Dockerfile
+++ b/node-red-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM nodered/node-red:latest
+FROM nodered/node-red:3.0.2-16
 
 ARG REGISTRY
 ARG REGISTRY_TOKEN

--- a/node-red-container/Dockerfile-3.1
+++ b/node-red-container/Dockerfile-3.1
@@ -1,4 +1,4 @@
-FROM nodered/node-red-dev:3.1.0-beta.3-18
+FROM nodered/node-red:3.1.0-16
 
 ARG REGISTRY
 ARG REGISTRY_TOKEN


### PR DESCRIPTION
## Description

This updates the Node-RED container images to include 3.1.0.

 - Pin `Dockerfile` to `3.0.2` rather than `latest`
 - Update `Dockerfile-3.1` to use release container, not dev stream container
 - Update container workflow to build 3.1.0 containers - and be explicit on which Dockerfile each should build from