### PR TITLE
Pin reusable workflow to commit SHA

### DIFF
--- a/.github/workflows/fileserver-container.yml
+++ b/.github/workflows/fileserver-container.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build-stage:
-    uses: flowforge/github-actions-workflows/.github/workflows/build_container_image.yml@main
+    uses: flowforge/github-actions-workflows/.github/workflows/build_container_image.yml@e3e734b910af78371b2c9a1c6856446d17421f50
     with:
       environment: 'stage'
       image_name: 'file-server'
@@ -34,7 +34,7 @@ jobs:
   build-prod:
     name: Build production image
     if: false
-    uses: flowforge/github-actions-workflows/.github/workflows/build_container_image.yml@main
+    uses: flowforge/github-actions-workflows/.github/workflows/build_container_image.yml@e3e734b910af78371b2c9a1c6856446d17421f50
     with:
       environment: 'production'
       image_name: 'file-server'

--- a/.github/workflows/flowforge-container.yml
+++ b/.github/workflows/flowforge-container.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   build-stage:
     name: Build stage image
-    uses: flowforge/github-actions-workflows/.github/workflows/build_container_image.yml@main
+    uses: flowforge/github-actions-workflows/.github/workflows/build_container_image.yml@e3e734b910af78371b2c9a1c6856446d17421f50
     with:
       environment: 'stage'
       image_name: 'forge-k8s'
@@ -36,7 +36,7 @@ jobs:
   build-prod:
     name: Build production image
     if: false
-    uses: flowforge/github-actions-workflows/.github/workflows/build_container_image.yml@main
+    uses: flowforge/github-actions-workflows/.github/workflows/build_container_image.yml@e3e734b910af78371b2c9a1c6856446d17421f50
     with:
       environment: 'production'
       image_name: 'forge-k8s'

--- a/.github/workflows/nodered-container.yml
+++ b/.github/workflows/nodered-container.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build-stage-302:
-    uses: flowforge/github-actions-workflows/.github/workflows/build_container_image.yml@main
+    uses: flowforge/github-actions-workflows/.github/workflows/build_container_image.yml@e3e734b910af78371b2c9a1c6856446d17421f50
     with:
       environment: 'stage'
       image_name: 'node-red'
@@ -32,7 +32,7 @@ jobs:
       aws_access_key_id: ${{ secrets.STAGING_AWS_ID }}
       aws_access_key_secret: ${{ secrets.STAGING_AWS_KEY }}
   build-stage-223:
-    uses: flowforge/github-actions-workflows/.github/workflows/build_container_image.yml@main
+    uses: flowforge/github-actions-workflows/.github/workflows/build_container_image.yml@e3e734b910af78371b2c9a1c6856446d17421f50
     with:
       environment: 'stage'
       image_name: 'node-red'
@@ -47,7 +47,7 @@ jobs:
       aws_access_key_id: ${{ secrets.STAGING_AWS_ID }}
       aws_access_key_secret: ${{ secrets.STAGING_AWS_KEY }}
   build-stage-310:
-    uses: flowforge/github-actions-workflows/.github/workflows/build_container_image.yml@main
+    uses: flowforge/github-actions-workflows/.github/workflows/build_container_image.yml@e3e734b910af78371b2c9a1c6856446d17421f50
     with:
       environment: 'stage'
       image_name: 'node-red'


### PR DESCRIPTION
## Description

Pin reusable workflow to commit SHA instead of branch name.

## Related Issue(s)

[220](https://github.com/flowforge/CloudProject/issues/220)

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

