### PR TITLE
Only config file-server if needed

### DIFF
--- a/helm/flowforge/templates/configmap.yaml
+++ b/helm/flowforge/templates/configmap.yaml
@@ -155,7 +155,7 @@ data:
         hubspot:
           trackingcode: {{ .Values.forge.support.hubspot | int }}
     {{- end }}
-    {{- if .Values.forge.fileStore }}
+    {{- if .Values.forge.fileStore.enabled }}
     fileStore:
       url: http://flowforge-file.{{ .Release.Namespace }}
     {{- end }}


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
flowforge.yml was including fileStore key even if file-server disabled

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

