### PR TITLE
fix: role binding references

### DIFF
--- a/helm/flowforge/templates/service-account.yaml
+++ b/helm/flowforge/templates/service-account.yaml
@@ -35,7 +35,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ ((.Values.forge).clusterRole).name | default "create-pod" }}
-  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "forge.labels" . | nindent 4 }}
 rules:
@@ -68,6 +67,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: flowforge
+  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name:  {{ ((.Values.forge).clusterRole).name | default "create-pod" }}


### PR DESCRIPTION
## Description

This pull request fixes a bug introduced in the [previous PR](https://github.com/FlowFuse/helm/pull/365/files#diff-919297a6fc5cbc1ae3b773decd3fc2fb826503be1d08ac21ecce054914efcab0L69).
The problem was that the role binding did not reference the correct service account used by the application pod. As a result, the instance creation process failed due to insufficient permissions to start the pod in a different namespace.

## Related Issue(s)

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

