### PR TITLE
fix: Ensure EMQX only used if teambroker enabeld

### DIFF
--- a/helm/flowforge/templates/configmap.yaml
+++ b/helm/flowforge/templates/configmap.yaml
@@ -160,7 +160,7 @@ data:
       {{ if .Values.forge.broker.url -}}
       url: {{ .Values.forge.broker.url }}
       {{ else -}}
-      {{ if .Values.forge.broker.teamBroker }}
+      {{ if .Values.forge.broker.teamBroker.enabled }}
       url: mqtt://emqx-listeners.{{ .Release.Namespace }}:1883
       {{ else -}}
       url: mqtt://flowforge-broker.{{ .Release.Namespace }}:1883


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Wrong service name used if `forge.teamBroker` exists when it should be checking `forge.teamBroker.enabled`

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

