### PR TITLE
fix: emqx secret key name typo

### DIFF
--- a/helm/flowforge/templates/emqx.yaml
+++ b/helm/flowforge/templates/emqx.yaml
@@ -221,7 +221,7 @@ type: Opaque
 data:
     EMQX_DASHBOARD__DEFAULT_PASSWORD: {{ "topSecret" | b64enc | quote }}
     api-key-name: {{ "flowfuse" | b64enc | quote }} 
-    apit-key-secret:  {{ "verySecret" | b64enc | quote }} 
+    api-key-secret:  {{ "verySecret" | b64enc | quote }} 
 ---
 {{- end }}
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
## Description

This pull request fixes typo in EMQX secrets

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

