### PR TITLE
chore: Update helm chart release configuration (part 2.5)

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -25,13 +25,13 @@
     [
       "@semantic-release/changelog",
       {
-        "changelogFile": "helm/flowforge/CHANGELOG.md"
+        "changelogFile": "helm/flowfuse/CHANGELOG.md"
       }
     ],
     [
       "semantic-release-helm3",
       {
-          "chartPath": "helm/flowforge",
+          "chartPath": "helm/flowfuse",
           "onlyUpdateVersion": true
       }
     ]


### PR DESCRIPTION
## Description

This pull request updates the semantic-release plugin  configuration to ensure, that only `flowfuse` helm chart will be verified for new changes.

## Related Issue(s)

https://github.com/FlowFuse/helm/issues/486

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

