### PR TITLE
feat: Bump app version in `flowfuse` helm chart to 2.17

### DIFF
--- a/helm/flowfuse/Chart.yaml
+++ b/helm/flowfuse/Chart.yaml
@@ -19,4 +19,4 @@ dependencies:
 maintainers:
   - name: "FlowFuse Inc"
     url: "https://flowfuse.com"
-appVersion: "2.16.0"
+appVersion: "2.17.0"


### PR DESCRIPTION
## Description

This pull request bumps the application varion in `flowfuse` helm chart to `2.17.0`

## Related Issue(s)

https://github.com/FlowFuse/helm/issues/486

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

