### PR TITLE
ci: Run `Helm chart validation` pipeline against `flowfuse` helm chart

### DIFF
--- a/.github/configs/chart-testing.yaml
+++ b/.github/configs/chart-testing.yaml
@@ -1,5 +1,5 @@
 remote: origin
 target-branch: main
 charts:
-  - ./helm/flowforge
+  - ./helm/flowfuse
 validate-maintainers: false

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Validate chart
         run: |
-          helm template flowforge ./helm/flowforge --set forge.domain=example.com | kubectl apply --validate=true -f -
+          helm template flowfuse ./helm/flowfuse --set forge.domain=example.com | kubectl apply --validate=true -f -
 
   unit-tests:
     name: Run unit tests
@@ -96,7 +96,7 @@ jobs:
 
       - name: Run unit tests
         run: |
-          helm unittest ./helm/flowforge -t JUnit -o junit-results.xml
+          helm unittest ./helm/flowfuse -t JUnit -o junit-results.xml
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@cf701569b05ccdd861a76b8607a66d76f6fd4857 # v5.5.1
@@ -135,8 +135,8 @@ jobs:
         uses: bridgecrewio/checkov-action@0482f7fa9969ae210b3f8535b9a57348775130b7 # v12.3005.0
         with:
           directory: ${{ github.workspace }}/helm
-          var_file: ${{ github.workspace }}/helm/flowforge/ci/default-values.yaml
-          skip_path: /flowforge/charts/
+          var_file: ${{ github.workspace }}/helm/flowfuse/ci/default-values.yaml
+          skip_path: /flowfuse/charts/
           framework: helm
           output_format: cli,sarif
           output_file_path: console,results.sarif
@@ -148,7 +148,7 @@ jobs:
         # temporary disabled due to https://github.com/zegl/kube-score/issues/559
         if: false
         run: |
-          helm template flowforge ./helm/flowforge --set forge.domain=example.com > ${{ github.workspace }}/templated_chart.yaml
+          helm template flowfuse ./helm/flowfuse --set forge.domain=example.com > ${{ github.workspace }}/templated_chart.yaml
       
       - name: Install kube-score
         # temporary disabled due to https://github.com/zegl/kube-score/issues/559


### PR DESCRIPTION
## Description

This pull request updates the `Helm chart validation` pipeline and related configuration file to ensure, that `flowfuse` helm chart will be valiated by the pipeline.

## Related Issue(s)

https://github.com/FlowFuse/helm/issues/486

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

