### PR TITLE
docs: Add instructions on switching helm chart

### DIFF
--- a/helm/flowfuse/README.md
+++ b/helm/flowfuse/README.md
@@ -360,7 +360,7 @@ In order to switch from `flowforge` to `flowfuse`, please follow these steps:
    flowfuse-helm-charts/flowfuse	2.35.0       	2.17.0     	FlowFuse
    ```
 
-3. Upgrade the release to use the `flowfuse` chart:
+3. Upgrade theexisting `my-flowfuse-release` release to use the `flowfuse` chart:
    ```bash
    helm upgrade --install my-flowfuse-release flowfuse-helm-charts/flowfuse --namespace default --values path/to/your/values.yaml
    ```


### PR DESCRIPTION
## Description

This pull request adds how-to instructions to helm chart documentation on how to switch from `flowforge` to `flowfuse` helm chart on existing helm release.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

