### PR TITLE
fix: Update verbs for deployments in ClusterRole to include 'update'

### DIFF
--- a/helm/flowfuse/templates/service-account.yaml
+++ b/helm/flowfuse/templates/service-account.yaml
@@ -43,7 +43,7 @@ rules:
   verbs: ["create", "patch", "get", "list", "watch", "delete"] 
 - apiGroups: ["apps"]
   resources: ["deployments", "deployment/status"]
-  verbs: ["create", "patch", "get", "list", "watch", "delete"]
+  verbs: ["create", "patch", "get", "list", "update", "watch", "delete"]
 - apiGroups: [""]
   resources: ["persistentvolumes", "persistentvolumeclaims"]
   verbs: ["create", "patch", "get", "list", "watch", "delete"] 


### PR DESCRIPTION
## Description

This pull request updates the verbs list for deployment resources in the `ClusterRole` by adding the `update` action.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

