### PR TITLE
feat: Add possibility to configure projects `containerSecurityContext`

### DIFF
--- a/helm/flowfuse/README.md
+++ b/helm/flowfuse/README.md
@@ -40,6 +40,7 @@ For other values please refer to the documentation below.
  - `forge.projectIngressAnnotations` ingress annotations for project instances (default is `{}`)
  - `forge.projectServiceType` service type for project instances (allowed `ClusterIP` or `NodePort`, default is `ClusterIP`)
  - `forge.projectPodSecurityContext` allows to configure [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the project pods
+ - `forge.projectContainerSecurityContext` allows to configure [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the project container
  - `forge.projectLabels` allows to add custom labels to all project-related resources (default `{}`)
  - `forge.managementSelector` a collection of labels and values to filter nodes the Forge App will run on (default `role: management`)
  - `forge.affinity` allows to configure [affinity or anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the core application pod

--- a/helm/flowfuse/templates/configmap.yaml
+++ b/helm/flowfuse/templates/configmap.yaml
@@ -102,6 +102,10 @@ data:
         podSecurityContext:
 {{ toYaml .Values.forge.projectPodSecurityContext | indent 10 }}
         {{- end }}
+  {{- if .Values.forge.projectContainerSecurityContext }}
+        containerSecurityContext:
+{{ toYaml .Values.forge.projectContainerSecurityContext | indent 10 }}
+        {{- end }}
     {{- if .Values.forge.email }}
     email:
       enabled: true

--- a/helm/flowfuse/tests/configmap_test.yaml
+++ b/helm/flowfuse/tests/configmap_test.yaml
@@ -1,0 +1,96 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test configmap security contexts
+templates:
+  - configmap.yaml
+set:
+  forge.domain: "chart-unit-tests.com"
+tests:
+  - it: should not render containerSecurityContext by default
+    asserts:
+      - notMatchRegex:
+          path: data["flowforge.yml"]
+          pattern: "containerSecurityContext:"
+
+  - it: should not render podSecurityContext when forge.projectPodSecurityContext is null
+    set:
+      forge.projectPodSecurityContext: null
+    asserts:
+      - notMatchRegex:
+          path: data["flowforge.yml"]
+          pattern: "podSecurityContext:"
+
+  - it: should render podSecurityContext when forge.projectPodSecurityContext is set
+    set:
+      forge.projectPodSecurityContext:
+        runAsUser: 2001
+        runAsGroup: 2002
+        fsGroup: 2003
+    asserts:
+      - matchRegex:
+          path: data["flowforge.yml"]
+          pattern: "podSecurityContext:"
+      - matchRegex:
+          path: data["flowforge.yml"]
+          pattern: "runAsUser: 2001"
+      - matchRegex:
+          path: data["flowforge.yml"]
+          pattern: "runAsGroup: 2002"
+      - matchRegex:
+          path: data["flowforge.yml"]
+          pattern: "fsGroup: 2003"
+
+  - it: should render containerSecurityContext when forge.projectContainerSecurityContext is set
+    set:
+      forge.projectContainerSecurityContext:
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
+        readOnlyRootFilesystem: true
+    asserts:
+      - matchRegex:
+          path: data["flowforge.yml"]
+          pattern: "containerSecurityContext:"
+      - matchRegex:
+          path: data["flowforge.yml"]
+          pattern: "allowPrivilegeEscalation: false"
+      - matchRegex:
+          path: data["flowforge.yml"]
+          pattern: "runAsNonRoot: true"
+      - matchRegex:
+          path: data["flowforge.yml"]
+          pattern: "readOnlyRootFilesystem: true"
+
+  - it: should render both podSecurityContext and containerSecurityContext when both are set
+    set:
+      forge.projectPodSecurityContext:
+        runAsUser: 2001
+        runAsGroup: 2002
+      forge.projectContainerSecurityContext:
+        runAsNonRoot: true
+        capabilities:
+          drop:
+            - ALL
+    asserts:
+      - matchRegex:
+          path: data["flowforge.yml"]
+          pattern: "podSecurityContext:"
+      - matchRegex:
+          path: data["flowforge.yml"]
+          pattern: "runAsUser: 2001"
+      - matchRegex:
+          path: data["flowforge.yml"]
+          pattern: "runAsGroup: 2002"
+      - matchRegex:
+          path: data["flowforge.yml"]
+          pattern: "containerSecurityContext:"
+      - matchRegex:
+          path: data["flowforge.yml"]
+          pattern: "runAsNonRoot: true"
+      - matchRegex:
+          path: data["flowforge.yml"]
+          pattern: "capabilities:"
+      - matchRegex:
+          path: data["flowforge.yml"]
+          pattern: "drop:"
+      - matchRegex:
+          path: data["flowforge.yml"]
+          pattern: "- ALL"

--- a/helm/flowfuse/values.schema.json
+++ b/helm/flowfuse/values.schema.json
@@ -180,6 +180,9 @@
                 "projectPodSecurityContext": {
                     "type": "object"
                 },
+                "projectContainerSecurityContext": {
+                    "type": "object"
+                },
                 "managementSelector": {
                     "type": "object"
                 },


### PR DESCRIPTION
## Description

This pull request introduces the `forge.projectContainerSecurityContext` configuration paramater that allows to define the security context on a Node-RED container level passing these values to the kubernetes driver.
This will work once https://github.com/FlowFuse/driver-k8s/pull/250 is released.

## Related Issue(s)

https://github.com/FlowFuse/driver-k8s/issues/249

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

