### PR TITLE
ci: Switch to OIDC authentication in the `File-server - build and deploy` workflow

### DIFF
--- a/.github/workflows/fileserver-container.yml
+++ b/.github/workflows/fileserver-container.yml
@@ -42,7 +42,7 @@ jobs:
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
 
   upload-stage-image:
-    # if: github.ref_name == 'main'
+    if: github.ref_name == 'main'
     name: Upload image to staging registry
     needs: build
     uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.43.0
@@ -60,7 +60,7 @@ jobs:
       eks_cluster_name: ${{ secrets.EKS_CLUSTER_NAME }}
 
   upload-production-image:
-    # if: github.ref_name == 'main'
+    if: github.ref_name == 'main'
     name: Upload image to production registry
     needs: build
     uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.43.0
@@ -78,8 +78,7 @@ jobs:
       eks_cluster_name: ${{ secrets.EKS_CLUSTER_NAME }}
 
   update-images:
-    # if: github.ref_name == 'main'
-    if: false
+    if: github.ref_name == 'main'
     name: Update images
     needs: [upload-production-image, upload-stage-image]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

This pull request switches to OIDC authentication when uploading container images to ECR registries in the `File-server - build and deploy` workflow.

## Related Issue(s)

Closes https://github.com/FlowFuse/helm/issues/684

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

