### PR TITLE
ci: Switch to OIDC authentication in the `Flowforge - build and deploy` workflow

### DIFF
--- a/.github/workflows/flowforge-container.yml
+++ b/.github/workflows/flowforge-container.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   build:
     name: Build single-architecture container images
-    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.42.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.43.0
     with:
       image_name: 'forge-k8s'
       package_dependencies: |
@@ -47,7 +47,7 @@ jobs:
     if: github.ref_name == 'main'
     name: Upload image to staging registry
     needs: build
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.42.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.43.0
     with:
       environment: stage
       service_name: 'forge-k8s'
@@ -55,9 +55,9 @@ jobs:
       container_name: forge
       deploy: false
       image: ${{ needs.build.outputs.image }}
+      aws_ecr_iam_role_name: ECR_push_pull_images
     secrets:
-      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws_secret_access_key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
+      aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
       eks_cluster_name: ${{ secrets.EKS_CLUSTER_NAME }}
 
@@ -65,7 +65,7 @@ jobs:
     if: github.ref_name == 'main'
     name: Upload image to production registry
     needs: build
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.42.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.43.0
     with:
       environment: production
       service_name: 'forge-k8s'
@@ -73,9 +73,9 @@ jobs:
       container_name: forge
       deploy: false
       image: ${{ needs.build.outputs.image }}
+      aws_ecr_iam_role_name: ECR_push_pull_images
     secrets:
-      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws_secret_access_key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
+      aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
       eks_cluster_name: ${{ secrets.EKS_CLUSTER_NAME }}
 


### PR DESCRIPTION
## Description

This pull request switches to OIDC authentication when uploading container images to ECR registries in the `Flowforge - build and deploy` workflow.

## Related Issue(s)

Closes https://github.com/FlowFuse/helm/issues/685

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

