### PR TITLE
chore: Remove under used NR versions from Editor Cache

### DIFF
--- a/flowforge-container/install-device-cache.sh
+++ b/flowforge-container/install-device-cache.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -x
 
-VERSION_LIST="4.0.4 4.0.5 4.0.7 4.0.8 4.0.9 4.1.0 4.1.1"
+VERSION_LIST="4.0.4 4.0.5 4.0.7 4.0.8 4.0.9 4.1.0 4.1.1 4.1.2"
 
 mkdir -p device/cache
 cd device/cache


### PR DESCRIPTION
## Description
Removed NR verisons
- 4.0.0
- 4.0.1
- 4.0.2
- 4.0.3

Looking at the in use versions these were all under 10 instances
<!-- Describe your changes in detail -->

## Related Issue(s)

<!-- What issue does this PR relate to? -->
https://github.com/FlowFuse/flowfuse/issues/6159

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

