### PR TITLE
fix: configmap templating for customHostname parameter

### DIFF
--- a/helm/flowfuse/templates/configmap.yaml
+++ b/helm/flowfuse/templates/configmap.yaml
@@ -96,9 +96,9 @@ data:
         {{- if .Values.forge.customHostname }}
         customHostname:
           enabled: {{ .Values.forge.customHostname.enabled }}
-          {{- if default false .Values.forge.customHostname.enabled -}}
+          {{- if default false .Values.forge.customHostname.enabled }}
           cnameTarget: {{ required "A value is required for .Values.forge.customHostname.cnameTarget" .Values.forge.customHostname.cnameTarget }}
-          {{- end -}}
+          {{- end }}
         {{- if .Values.forge.customHostname.certManagerIssuer }}
           certManagerIssuer: {{ .Values.forge.customHostname.certManagerIssuer }}
         {{- end }}


### PR DESCRIPTION
## Description

This pull request fixes the configMap templating when customHostname is enabled.

## Related Issue(s)

https://github.com/FlowFuse/CloudProject/issues/954

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

