### PR TITLE
fix: Allow fileStorage.context.options.ssl to be set

### DIFF
--- a/helm/flowfuse/templates/file-storage-configmap.yaml
+++ b/helm/flowfuse/templates/file-storage-configmap.yaml
@@ -31,6 +31,9 @@ data:
         {{- if eq .Values.forge.fileStore.context.options.type "postgres" }}
         host: {{ include "forge.databaseHost" . }}
         port: {{ .Values.postgresql.port | default 5432 }}
+        {{- if .Values.postgresql.ssl }}
+        ssl: {{ .Values.postgresql.ssl }}
+        {{- end }}
         username: {{ .Values.postgresql.auth.username }}
         database: {{ .Values.postgresql.auth.fileStoreDatabase }}
         password: <%= ENV['PGPASSWORD'] %>


### PR DESCRIPTION
part of FlowFuse/file-server#178

## Description

<!-- Describe your changes in detail -->

Allows SSL option to be passed to the PG driver. Should not be merged before FlowFuse/file-server#179 ships

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

