### PR TITLE
fix: EMQX broker affinity and tolerations indentation

### DIFF
--- a/helm/flowfuse/templates/emqx.yaml
+++ b/helm/flowfuse/templates/emqx.yaml
@@ -61,11 +61,12 @@ spec:
                 mountPath: /mounted/config/api-keys
                 subPath: api-keys
             {{- if .Values.forge.broker.affinity }}
-            affinity: {{ toYaml .Values.forge.broker.affinity | indent 12 }}
+            affinity: 
+{{ toYaml .Values.forge.broker.affinity | indent 14 }}
             {{- end }}
             {{- if .Values.forge.broker.tolerations}}
             tolerations:
-            {{ toYaml .Values.forge.broker.tolerations | nindent 12 }}
+{{ toYaml .Values.forge.broker.tolerations | indent 14 }}
             {{- end }}
     listenersServiceTemplate:
         {{- if .Values.broker.listenersServiceTemplate }}


### PR DESCRIPTION
## Description

This pull request fixes the indentation for `spec.coreTemplate.spec.affinity` and `spec.coreTemplate.spec.tolerations` values in the `EMQX` manifest template.

## Related Issue(s)

https://github.com/FlowFuse/CloudProject/issues/993

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

