### PR TITLE
Fix typo in README for fileStoreDatabase

### DIFF
--- a/helm/flowfuse/README.md
+++ b/helm/flowfuse/README.md
@@ -336,7 +336,7 @@ editors:
 - `postgresql.auth.password` - the password to use to connect to the database (default `Zai1Wied`)
 - `postgresql.auth.database` - the database to use (default `flowforge`)
 - `postgresql.auth.postgresPassword` - the password to use for the postgres user (default `Moomiet0`)
-- `postgresql.auth.fileStoreDatabase` - the database to use bt the File Storage servive (default `ff-context`)
+- `postgresql.auth.fileStoreDatabase` - the database to use bt the File Storage service (default `ff-context`)
 - `postgresql.auth.existingSecret` - the name of an Kubernetes secret object with database credentials (If `postgresql.auth.existingSecret` is set, `postgresql.auth.password` and `postgresql.auth.postgresPassword` values are ignored; default not set)
 - `postgresql.image.registry` - registry host for local PostgreSQL instance (default `docker.io`)
 


### PR DESCRIPTION
Corrected a typo in the README regarding the File Storage service.

## Description

Corrected a typo in the README regarding the File Storage service.

## Related Issue(s)



## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? --> Corrected a typo in the README 
 - [ x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

