### PR TITLE
fix: Ensure that sticky-session annotations are always added to the `flowforge-ingress-api-devices` ingress resource

### DIFF
--- a/helm/flowfuse/templates/service-ingress.yaml
+++ b/helm/flowfuse/templates/service-ingress.yaml
@@ -74,12 +74,10 @@ metadata:
   {{- if .Values.ingress.certManagerIssuer }}
     cert-manager.io/cluster-issuer: {{ .Values.ingress.certManagerIssuer }}
   {{- end }}
-  {{- if .Values.ingress.annotations }}
     nginx.ingress.kubernetes.io/affinity: cookie
     nginx.ingress.kubernetes.io/affinity-mode: persistent
     nginx.ingress.kubernetes.io/session-cookie-name: FFSESSION
     nginx.ingress.kubernetes.io/session-cookie-samesite: Strict
-  {{- end }}
   {{- $filteredAnnotations := include "forge.filteredIngressAnnotations" . | replace "{{ instanceHost }}" $forgeHostname | replace "{{ serviceName }}" "forge" }}
   {{- if $filteredAnnotations }}
 {{ $filteredAnnotations | indent 4 }}


### PR DESCRIPTION
## Description

This pull request ensures that the sticky session ingress annotations are always configured for the `flowforge-ingress-api-devices` ingress object.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

