### PR TITLE
fix: Remove trailing slash from the path in the `flowforge-ingress-api-devices` ingress resource

### DIFF
--- a/helm/flowfuse/templates/service-ingress.yaml
+++ b/helm/flowfuse/templates/service-ingress.yaml
@@ -91,7 +91,7 @@ spec:
     http:
       paths:
       - pathType: Prefix
-        path: "/api/v1/devices/"
+        path: "/api/v1/devices"
         backend:
           service:
             name: forge


### PR DESCRIPTION
## Description

This pull request removes the trailing slash from the path defined in the `flowforge-ingress-api-devices` ingress resource.
This fixes problem when onboarding the Remote Instance using provisioning token.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

