### PR TITLE
fix: Add the session cookie path for Device Agent Editor Proxy

### DIFF
--- a/helm/flowfuse/templates/service-ingress.yaml
+++ b/helm/flowfuse/templates/service-ingress.yaml
@@ -78,6 +78,7 @@ metadata:
     nginx.ingress.kubernetes.io/affinity-mode: persistent
     nginx.ingress.kubernetes.io/session-cookie-name: FFSESSION
     nginx.ingress.kubernetes.io/session-cookie-samesite: Strict
+    nginx.ingress.kubernetes.io/session-cookie-path: /api/v1/devices
   {{- $filteredAnnotations := include "forge.filteredIngressAnnotations" . | replace "{{ instanceHost }}" $forgeHostname | replace "{{ serviceName }}" "forge" }}
   {{- if $filteredAnnotations }}
 {{ $filteredAnnotations | indent 4 }}


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Ensure that the Session Cookie path is set to /api/v1/devices

