### PR TITLE
fix: Configure the team broker api only when config is provided

### DIFF
--- a/helm/flowfuse/templates/configmap.yaml
+++ b/helm/flowfuse/templates/configmap.yaml
@@ -224,10 +224,12 @@ data:
       teamBroker:
         enabled: true
         host: {{ include "forge.teamBrokerHost" . }}
+        {{- if .Values.forge.broker.teamBroker.api }}
         api:
           url: {{ include "forge.teamBrokerApiUrl" . }}
           key: {{ .Values.forge.broker.teamBroker.api.key }}
           secret: <%= ENV['TEAM_BROKER_API_SECRET'] %>
+        {{- end }}
       {{ end -}}
     {{- end }}
     logging:


### PR DESCRIPTION
## Description

This pull request ensures that the Team Broker API configuration is templated only when `.Values.forge.broker.teamBroker.api ` exists.

## Related Issue(s)

Closes https://github.com/FlowFuse/helm/issues/894

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

