### PR TITLE
chore: bump forge and file-server containers to Node v24

### DIFF
--- a/file-server/Dockerfile
+++ b/file-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:24-alpine
 
 ARG TAG
 

--- a/flowforge-container/Dockerfile
+++ b/flowforge-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:24-alpine
 
 ARG TAG
 


### PR DESCRIPTION
part of https://github.com/FlowFuse/flowfuse/issues/6951

## Description

<!-- Describe your changes in detail -->
Upgrade base containers to NodeJS 24, all components should already be tested at NodeJS 24 as part of pipeline

## Related Issue(s)

<!-- What issue does this PR relate to? -->
https://github.com/FlowFuse/flowfuse/issues/6951

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

