### PR TITLE
fix: Ensure the team broker api key and secret are not templated when not defined

### DIFF
--- a/helm/flowfuse/templates/_helpers.tpl
+++ b/helm/flowfuse/templates/_helpers.tpl
@@ -373,9 +373,9 @@ Resolve Team Broker API URL: user-provided value, or default to the in-cluster E
 Create Team Broker API secret
 */}}
 {{- define "forge.teamBrokerApiSecret" -}}
-{{- if (.Values.forge.broker.teamBroker).enabled -}}
-{{- $_ := required "A valid .Values.forge.broker.teamBroker.api.key is required!" ((.Values.forge.broker.teamBroker).api).key -}}
-{{- $token := required "A valid .Values.forge.broker.teamBroker.api.secret is required!" ((.Values.forge.broker.teamBroker).api).secret -}}
+{{- if and (.Values.forge.broker.teamBroker).enabled (.Values.forge.broker.teamBroker).api -}}
+{{- $_ := required "A valid .Values.forge.broker.teamBroker.api.key is required!" .Values.forge.broker.teamBroker.api.key -}}
+{{- $token := required "A valid .Values.forge.broker.teamBroker.api.secret is required!" .Values.forge.broker.teamBroker.api.secret -}}
 teamBrokerApiSecret: {{ $token | b64enc | quote }}
 {{- end -}}
 {{- end -}}

--- a/helm/flowfuse/templates/deployment.yaml
+++ b/helm/flowfuse/templates/deployment.yaml
@@ -90,7 +90,7 @@ spec:
                 key: expertToken
                 optional: true
         {{- end }}
-        {{- if (.Values.forge.broker.teamBroker).enabled }}
+        {{- if and (.Values.forge.broker.teamBroker).enabled (.Values.forge.broker.teamBroker).api }}
           - name: TEAM_BROKER_API_SECRET
             valueFrom:
               secretKeyRef:

--- a/helm/flowfuse/tests/team_broker_api_test.yaml
+++ b/helm/flowfuse/tests/team_broker_api_test.yaml
@@ -44,6 +44,38 @@ tests:
           path: data["flowforge.yml"]
           pattern: "secret: team-broker-secret"
 
+  - it: should render teamBroker block without api sub-block when teamBroker is enabled but api is missing
+    template: configmap.yaml
+    set:
+      forge.broker.enabled: true
+      forge.broker.teamBroker:
+        enabled: true
+    asserts:
+      - matchRegex:
+          path: data["flowforge.yml"]
+          pattern: "teamBroker:"
+      - notMatchRegex:
+          path: data["flowforge.yml"]
+          pattern: "api:"
+      - notMatchRegex:
+          path: data["flowforge.yml"]
+          pattern: "TEAM_BROKER_API_SECRET"
+
+  - it: should render teamBroker block without api sub-block when teamBroker is enabled but api is empty
+    template: configmap.yaml
+    set:
+      forge.broker.enabled: true
+      forge.broker.teamBroker:
+        enabled: true
+        api: {}
+    asserts:
+      - matchRegex:
+          path: data["flowforge.yml"]
+          pattern: "teamBroker:"
+      - notMatchRegex:
+          path: data["flowforge.yml"]
+          pattern: "api:"
+
   # Deployment tests
   - it: should not include TEAM_BROKER_API_SECRET env var by default
     template: deployment.yaml
@@ -79,6 +111,25 @@ tests:
                 name: flowfuse-secrets
                 key: teamBrokerApiSecret
                 optional: true
+
+  - it: should not include TEAM_BROKER_API_SECRET env var when teamBroker is enabled but api is missing
+    template: deployment.yaml
+    set:
+      forge.broker.teamBroker:
+        enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers[0].env[?(@.name == "TEAM_BROKER_API_SECRET")]
+
+  - it: should not include TEAM_BROKER_API_SECRET env var when teamBroker is enabled but api is empty
+    template: deployment.yaml
+    set:
+      forge.broker.teamBroker:
+        enabled: true
+        api: {}
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers[0].env[?(@.name == "TEAM_BROKER_API_SECRET")]
 
   # Secrets tests
   - it: should not include teamBrokerApiSecret in secrets by default
@@ -126,14 +177,16 @@ tests:
       - failedTemplate:
           errorMessage: "A valid .Values.forge.broker.teamBroker.api.secret is required!"
 
-  - it: should fail when teamBroker is enabled but api block is missing
+  - it: should not include teamBrokerApiSecret when teamBroker is enabled but api block is missing
     template: secrets.yaml
     set:
       forge.broker.teamBroker:
         enabled: true
     asserts:
-      - failedTemplate:
-          errorMessage: "A valid .Values.forge.broker.teamBroker.api.key is required!"
+      - isKind:
+          of: Secret
+      - notExists:
+          path: data.teamBrokerApiSecret
 
   # Coexistence with other secrets
   - it: should include teamBrokerApiSecret alongside other tokens when multiple features are enabled

--- a/helm/flowfuse/tests/team_broker_helpers_test.yaml
+++ b/helm/flowfuse/tests/team_broker_helpers_test.yaml
@@ -117,25 +117,29 @@ tests:
       - failedTemplate:
           errorMessage: "A valid .Values.forge.broker.teamBroker.api.secret is required!"
 
-  - it: should require api fields when teamBroker is enabled but api is empty
+  - it: should skip teamBrokerApiSecret rendering when teamBroker is enabled but api is empty
     template: secrets.yaml
     set:
       forge.broker.teamBroker:
         enabled: true
         api: {}
     asserts:
-      - failedTemplate:
-          errorMessage: "A valid .Values.forge.broker.teamBroker.api.key is required!"
+      - isKind:
+          of: Secret
+      - notExists:
+          path: data.teamBrokerApiSecret
 
-  - it: should require api fields when teamBroker is enabled but api is missing
+  - it: should skip teamBrokerApiSecret rendering when teamBroker is enabled but api is missing
     template: secrets.yaml
     set:
       forge.broker.teamBroker:
         enabled: true
         # api is missing
     asserts:
-      - failedTemplate:
-          errorMessage: "A valid .Values.forge.broker.teamBroker.api.key is required!"
+      - isKind:
+          of: Secret
+      - notExists:
+          path: data.teamBrokerApiSecret
 
   # forge.teamBrokerApiUrl helper - verified indirectly through the rendered configmap
   - it: should default api.url to in-cluster EMQX dashboard when not provided


### PR DESCRIPTION
## Description

This pull request ensures, that any references to the team broker api key and secret are not templated until `forge.broker.teamBroker.api` is not empty.

## Related Issue(s)

Fixes https://github.com/FlowFuse/helm/issues/900

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

