### PR TITLE
feat: Introduce Dockerfile for Node-RED 5 container 

### DIFF
--- a/node-red-container/Dockerfile
+++ b/node-red-container/Dockerfile
@@ -6,23 +6,23 @@ COPY healthcheck.js /healthcheck.js
 
 COPY package.json /data
 WORKDIR /data
-RUN mkdir node_modules
-RUN npm install --omit=dev --no-audit --no-fund
+RUN mkdir node_modules && \
+    npm install --omit=dev --no-audit --no-fund
 
 USER root
 RUN mkdir -p /usr/local/ssl-certs
 
 WORKDIR /usr/src/flowforge-nr-launcher
-RUN chown -R node-red:node-red /usr/src/flowforge-nr-launcher
-RUN ln -s /usr/src/flowforge-nr-launcher /usr/src/flowfuse-nr-launcher
+RUN chown -R node-red:node-red /usr/src/flowforge-nr-launcher && \
+    ln -s /usr/src/flowforge-nr-launcher /usr/src/flowfuse-nr-launcher
 
 USER node-red
 RUN --mount=type=secret,id=npm,uid=1000,target=/usr/src/node-red/.npmrc npm install @flowfuse/nr-launcher@${BUILD_TAG} --omit=dev --no-audit --no-fund
 
 USER root
-RUN mkdir -p /data/storage
-RUN chmod -R g+w /data/* /data/.npm/* 
-RUN chown -R node-red:root /data/* /data/.npm/* 
+RUN mkdir -p /data/storage && \
+    chmod -R g+w /data/* /data/.npm/* && \
+    chown -R node-red:root /data/* /data/.npm/*
 
 USER node-red
 

--- a/node-red-container/Dockerfile-2.2.x
+++ b/node-red-container/Dockerfile-2.2.x
@@ -12,12 +12,12 @@ USER root
 RUN mkdir -p /usr/local/ssl-certs
 
 WORKDIR /usr/src/flowforge-nr-launcher
-RUN mkdir -p /data/storage
-RUN chown node-red:node-red /data/* /usr/src/flowforge-nr-launcher
-RUN ln -s /usr/src/flowforge-nr-launcher /usr/src/flowfuse-nr-launcher
+RUN mkdir -p /data/storage && \
+    chown node-red:node-red /data/* /usr/src/flowforge-nr-launcher && \
+    ln -s /usr/src/flowforge-nr-launcher /usr/src/flowfuse-nr-launcher
 
 USER node-red
-RUN --mount=type=secret,id=npm,uid=1000,target=/usr/src/node-red/.npmrc npm install npm install @flowfuse/nr-launcher@${BUILD_TAG} --omit=dev --no-audit --no-fund
+RUN --mount=type=secret,id=npm,uid=1000,target=/usr/src/node-red/.npmrc npm install @flowfuse/nr-launcher@${BUILD_TAG} --omit=dev --no-audit --no-fund
 
 ENV NODE_PATH=/usr/src/node-red
 ENV HOME=/usr/src/node-red

--- a/node-red-container/Dockerfile-3.1
+++ b/node-red-container/Dockerfile-3.1
@@ -3,8 +3,8 @@ FROM nodered/node-red:3.1.15-18
 ARG BUILD_TAG=latest
 
 USER root
-RUN npm install -g npm
-RUN chown -R 1000:1000 "/data/.npm"
+RUN npm install -g npm && \
+    chown -R 1000:1000 "/data/.npm"
 
 USER node-red
 
@@ -12,23 +12,23 @@ COPY healthcheck.js /healthcheck.js
 
 COPY package.json /data
 WORKDIR /data
-RUN mkdir node_modules
-RUN npm install --omit=dev --no-audit --no-fund
+RUN mkdir node_modules && \
+    npm install --omit=dev --no-audit --no-fund
 
 USER root
 RUN mkdir -p /usr/local/ssl-certs
 
 WORKDIR /usr/src/flowforge-nr-launcher
-RUN chown -R node-red:node-red /usr/src/flowforge-nr-launcher
-RUN ln -s /usr/src/flowforge-nr-launcher /usr/src/flowfuse-nr-launcher
+RUN chown -R node-red:node-red /usr/src/flowforge-nr-launcher && \
+    ln -s /usr/src/flowforge-nr-launcher /usr/src/flowfuse-nr-launcher
 
 USER node-red
-RUN --mount=type=secret,id=npm,uid=1000,target=/usr/src/node-red/.npmrc npm install npm install @flowfuse/nr-launcher@${BUILD_TAG} --omit=dev --no-audit --no-fund
+RUN --mount=type=secret,id=npm,uid=1000,target=/usr/src/node-red/.npmrc npm install @flowfuse/nr-launcher@${BUILD_TAG} --omit=dev --no-audit --no-fund
 
 USER root
-RUN mkdir -p /data/storage
-RUN chmod -R g+w /data/* /data/.npm/* 
-RUN chown -R node-red:root /data/* /data/.npm/* 
+RUN mkdir -p /data/storage && \
+    chmod -R g+w /data/* /data/.npm/* && \ 
+    chown -R node-red:root /data/* /data/.npm/* 
 
 USER node-red
 

--- a/node-red-container/Dockerfile-4.0
+++ b/node-red-container/Dockerfile-4.0
@@ -3,8 +3,8 @@ FROM nodered/node-red:4.0.9-20
 ARG BUILD_TAG=latest
 
 USER root
-RUN npm install -g npm
-RUN chown -R 1000:1000 "/data/.npm"
+RUN npm install -g npm && \
+    chown -R 1000:1000 "/data/.npm"
 
 USER node-red
 
@@ -12,23 +12,23 @@ COPY healthcheck.js /healthcheck.js
 
 COPY package.json /data
 WORKDIR /data
-RUN mkdir node_modules
-RUN npm install --omit=dev --no-audit --no-fund
+RUN mkdir node_modules && \
+    npm install --omit=dev --no-audit --no-fund
 
 USER root
 RUN mkdir -p /usr/local/ssl-certs
 
 WORKDIR /usr/src/flowforge-nr-launcher
-RUN chown -R node-red:node-red /usr/src/flowforge-nr-launcher
-RUN ln -s /usr/src/flowforge-nr-launcher /usr/src/flowfuse-nr-launcher
+RUN chown -R node-red:node-red /usr/src/flowforge-nr-launcher && \
+    ln -s /usr/src/flowforge-nr-launcher /usr/src/flowfuse-nr-launcher
 
 USER node-red
-RUN --mount=type=secret,id=npm,uid=1000,target=/usr/src/node-red/.npmrc npm install npm install @flowfuse/nr-launcher@${BUILD_TAG} --omit=dev --no-audit --no-fund
+RUN --mount=type=secret,id=npm,uid=1000,target=/usr/src/node-red/.npmrc npm install @flowfuse/nr-launcher@${BUILD_TAG} --omit=dev --no-audit --no-fund
 
 USER root
-RUN mkdir -p /data/storage
-RUN chmod -R g+w /data/* /data/.npm/* 
-RUN chown -R node-red:root /data/* /data/.npm/* 
+RUN mkdir -p /data/storage && \
+    chmod -R g+w /data/* /data/.npm/* && \ 
+    chown -R node-red:root /data/* /data/.npm/* 
 
 USER node-red
 

--- a/node-red-container/Dockerfile-4.1
+++ b/node-red-container/Dockerfile-4.1
@@ -3,8 +3,8 @@ FROM nodered/node-red:4.1.11-22
 ARG BUILD_TAG=latest
 
 USER root
-RUN npm install -g npm
-RUN chown -R 1000:1000 "/data/.npm"
+RUN npm install -g npm && \
+    chown -R 1000:1000 "/data/.npm"
 
 USER node-red
 
@@ -12,23 +12,23 @@ COPY healthcheck.js /healthcheck.js
 
 COPY package.json /data
 WORKDIR /data
-RUN mkdir node_modules
-RUN npm install --omit=dev --no-audit --no-fund
+RUN mkdir node_modules && \
+    npm install --omit=dev --no-audit --no-fund
 
 USER root
 RUN mkdir -p /usr/local/ssl-certs
 
 WORKDIR /usr/src/flowforge-nr-launcher
-RUN chown -R node-red:node-red /usr/src/flowforge-nr-launcher
-RUN ln -s /usr/src/flowforge-nr-launcher /usr/src/flowfuse-nr-launcher
+RUN chown -R node-red:node-red /usr/src/flowforge-nr-launcher && \
+    ln -s /usr/src/flowforge-nr-launcher /usr/src/flowfuse-nr-launcher
 
 USER node-red
-RUN --mount=type=secret,id=npm,uid=1000,target=/usr/src/node-red/.npmrc npm install npm install @flowfuse/nr-launcher@${BUILD_TAG} --omit=dev --no-audit --no-fund
+RUN --mount=type=secret,id=npm,uid=1000,target=/usr/src/node-red/.npmrc npm install @flowfuse/nr-launcher@${BUILD_TAG} --omit=dev --no-audit --no-fund
 
 USER root
-RUN mkdir -p /data/storage
-RUN chmod -R g+w /data/* /data/.npm/* 
-RUN chown -R node-red:root /data/* /data/.npm/* 
+RUN mkdir -p /data/storage && \
+    chmod -R g+w /data/* /data/.npm/* && \ 
+    chown -R node-red:root /data/* /data/.npm/* 
 
 USER node-red
 

--- a/node-red-container/Dockerfile-5.0
+++ b/node-red-container/Dockerfile-5.0
@@ -1,0 +1,41 @@
+# TODO: set proper tag after Node-RED 5 release
+FROM nodered/node-red:5.0.0-22 
+
+ARG BUILD_TAG=latest
+
+USER root
+RUN npm install -g npm && \
+    chown -R 1000:1000 "/data/.npm"
+
+USER node-red
+
+COPY healthcheck.js /healthcheck.js
+
+COPY package.json /data
+WORKDIR /data
+RUN mkdir node_modules && \
+    npm install --omit=dev --no-audit --no-fund
+
+USER root
+RUN mkdir -p /usr/local/ssl-certs
+
+WORKDIR /usr/src/flowforge-nr-launcher
+RUN chown -R node-red:node-red /usr/src/flowforge-nr-launcher && \
+    ln -s /usr/src/flowforge-nr-launcher /usr/src/flowfuse-nr-launcher
+
+USER node-red
+RUN --mount=type=secret,id=npm,uid=1000,target=/usr/src/node-red/.npmrc npm install @flowfuse/nr-launcher@${BUILD_TAG} --omit=dev --no-audit --no-fund
+
+USER root
+RUN mkdir -p /data/storage && \
+    chmod -R g+w /data/* /data/.npm/* && \ 
+    chown -R node-red:root /data/* /data/.npm/* 
+
+USER node-red
+
+ENV NODE_PATH=/usr/src/node-red
+ENV HOME=/usr/src/node-red
+
+EXPOSE 2880
+
+ENTRYPOINT ["./node_modules/.bin/flowfuse-node-red", "-p", "2880", "-n", "/usr/src/node-red"]

--- a/node-red-container/Dockerfile-5.0
+++ b/node-red-container/Dockerfile-5.0
@@ -1,5 +1,5 @@
 # TODO: set proper tag after Node-RED 5 release
-FROM nodered/node-red:5.0.0-22 
+FROM nodered/node-red:5.0.0-24 
 
 ARG BUILD_TAG=latest
 


### PR DESCRIPTION
## Description

This pull request introduces the Dockerfile responsible for building the Node-RED 5 container used by FlowFuse platforms. 

Additionally, it reduces the number of layers created while building other Node-RED containers.

## Related Issue(s)

Closes https://github.com/FlowFuse/helm/issues/933

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

