### PR TITLE
feat: Add Node-RED 5 container build to the `Release container images` workflow

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -433,3 +433,63 @@ jobs:
           username: flowfuse
           password: ${{ secrets.DOCKER_HUB_PASSWORD_FLOWFUSE }}
           readme-filepath: ./helm/file-server/README.md
+
+  build_nodered_container_50:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: 'flowfuse/helm'
+          path: 'helm'
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@acca2b1b2070338fb9fd1ca27ecee81d687e58e5 # v6.1.2
+        with:
+          aws-region: ${{ env.AWS_ECR_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}:role/${{ env.AWS_ECR_ROLE_NAME }}
+          role-session-name: GithubActionsRoleSession
+          role-duration-seconds: 900
+        
+      - name: Login to AWS ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2.1.5
+        with:
+          registries: "${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}"
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: flowforge
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
+      - name: Docker Meta Data
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          tags: |
+            type=raw,enable=true,priority=200,prefix=,suffix=-5.0.x,value=${{ github.event.inputs.version }}
+            type=raw,enable=true,priority=200,prefix=latest-,suffix=,value=5.0.x
+          flavor: |
+            latest=true
+          images: |
+            flowforge/node-red
+            flowfuse/node-red
+            ${{ steps.login-ecr.outputs.registry}}/${{ env.AWS_ECR_NODE_RED_REPOSITORY_NAME }}
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Build and push Node-RED container
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: helm/node-red-container
+          file: helm/node-red-container/Dockerfile-5.0
+          platforms: linux/amd64, linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          push: true

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -473,7 +473,7 @@ jobs:
             type=raw,enable=true,priority=200,prefix=,suffix=-5.0.x,value=${{ github.event.inputs.version }}
             type=raw,enable=true,priority=200,prefix=latest-,suffix=,value=5.0.x
           flavor: |
-            latest=true
+            latest=false
           images: |
             flowforge/node-red
             flowfuse/node-red

--- a/node-red-container/Dockerfile
+++ b/node-red-container/Dockerfile
@@ -6,23 +6,23 @@ COPY healthcheck.js /healthcheck.js
 
 COPY package.json /data
 WORKDIR /data
-RUN mkdir node_modules
-RUN npm install --omit=dev --no-audit --no-fund
+RUN mkdir node_modules && \
+    npm install --omit=dev --no-audit --no-fund
 
 USER root
 RUN mkdir -p /usr/local/ssl-certs
 
 WORKDIR /usr/src/flowforge-nr-launcher
-RUN chown -R node-red:node-red /usr/src/flowforge-nr-launcher
-RUN ln -s /usr/src/flowforge-nr-launcher /usr/src/flowfuse-nr-launcher
+RUN chown -R node-red:node-red /usr/src/flowforge-nr-launcher && \
+    ln -s /usr/src/flowforge-nr-launcher /usr/src/flowfuse-nr-launcher
 
 USER node-red
 RUN --mount=type=secret,id=npm,uid=1000,target=/usr/src/node-red/.npmrc npm install @flowfuse/nr-launcher@${BUILD_TAG} --omit=dev --no-audit --no-fund
 
 USER root
-RUN mkdir -p /data/storage
-RUN chmod -R g+w /data/* /data/.npm/* 
-RUN chown -R node-red:root /data/* /data/.npm/* 
+RUN mkdir -p /data/storage && \
+    chmod -R g+w /data/* /data/.npm/* && \
+    chown -R node-red:root /data/* /data/.npm/*
 
 USER node-red
 

--- a/node-red-container/Dockerfile-2.2.x
+++ b/node-red-container/Dockerfile-2.2.x
@@ -12,12 +12,12 @@ USER root
 RUN mkdir -p /usr/local/ssl-certs
 
 WORKDIR /usr/src/flowforge-nr-launcher
-RUN mkdir -p /data/storage
-RUN chown node-red:node-red /data/* /usr/src/flowforge-nr-launcher
-RUN ln -s /usr/src/flowforge-nr-launcher /usr/src/flowfuse-nr-launcher
+RUN mkdir -p /data/storage && \
+    chown node-red:node-red /data/* /usr/src/flowforge-nr-launcher && \
+    ln -s /usr/src/flowforge-nr-launcher /usr/src/flowfuse-nr-launcher
 
 USER node-red
-RUN --mount=type=secret,id=npm,uid=1000,target=/usr/src/node-red/.npmrc npm install npm install @flowfuse/nr-launcher@${BUILD_TAG} --omit=dev --no-audit --no-fund
+RUN --mount=type=secret,id=npm,uid=1000,target=/usr/src/node-red/.npmrc npm install @flowfuse/nr-launcher@${BUILD_TAG} --omit=dev --no-audit --no-fund
 
 ENV NODE_PATH=/usr/src/node-red
 ENV HOME=/usr/src/node-red

--- a/node-red-container/Dockerfile-3.1
+++ b/node-red-container/Dockerfile-3.1
@@ -3,8 +3,8 @@ FROM nodered/node-red:3.1.15-18
 ARG BUILD_TAG=latest
 
 USER root
-RUN npm install -g npm
-RUN chown -R 1000:1000 "/data/.npm"
+RUN npm install -g npm && \
+    chown -R 1000:1000 "/data/.npm"
 
 USER node-red
 
@@ -12,23 +12,23 @@ COPY healthcheck.js /healthcheck.js
 
 COPY package.json /data
 WORKDIR /data
-RUN mkdir node_modules
-RUN npm install --omit=dev --no-audit --no-fund
+RUN mkdir node_modules && \
+    npm install --omit=dev --no-audit --no-fund
 
 USER root
 RUN mkdir -p /usr/local/ssl-certs
 
 WORKDIR /usr/src/flowforge-nr-launcher
-RUN chown -R node-red:node-red /usr/src/flowforge-nr-launcher
-RUN ln -s /usr/src/flowforge-nr-launcher /usr/src/flowfuse-nr-launcher
+RUN chown -R node-red:node-red /usr/src/flowforge-nr-launcher && \
+    ln -s /usr/src/flowforge-nr-launcher /usr/src/flowfuse-nr-launcher
 
 USER node-red
-RUN --mount=type=secret,id=npm,uid=1000,target=/usr/src/node-red/.npmrc npm install npm install @flowfuse/nr-launcher@${BUILD_TAG} --omit=dev --no-audit --no-fund
+RUN --mount=type=secret,id=npm,uid=1000,target=/usr/src/node-red/.npmrc npm install @flowfuse/nr-launcher@${BUILD_TAG} --omit=dev --no-audit --no-fund
 
 USER root
-RUN mkdir -p /data/storage
-RUN chmod -R g+w /data/* /data/.npm/* 
-RUN chown -R node-red:root /data/* /data/.npm/* 
+RUN mkdir -p /data/storage && \
+    chmod -R g+w /data/* /data/.npm/* && \ 
+    chown -R node-red:root /data/* /data/.npm/* 
 
 USER node-red
 

--- a/node-red-container/Dockerfile-4.0
+++ b/node-red-container/Dockerfile-4.0
@@ -3,8 +3,8 @@ FROM nodered/node-red:4.0.9-20
 ARG BUILD_TAG=latest
 
 USER root
-RUN npm install -g npm
-RUN chown -R 1000:1000 "/data/.npm"
+RUN npm install -g npm && \
+    chown -R 1000:1000 "/data/.npm"
 
 USER node-red
 
@@ -12,23 +12,23 @@ COPY healthcheck.js /healthcheck.js
 
 COPY package.json /data
 WORKDIR /data
-RUN mkdir node_modules
-RUN npm install --omit=dev --no-audit --no-fund
+RUN mkdir node_modules && \
+    npm install --omit=dev --no-audit --no-fund
 
 USER root
 RUN mkdir -p /usr/local/ssl-certs
 
 WORKDIR /usr/src/flowforge-nr-launcher
-RUN chown -R node-red:node-red /usr/src/flowforge-nr-launcher
-RUN ln -s /usr/src/flowforge-nr-launcher /usr/src/flowfuse-nr-launcher
+RUN chown -R node-red:node-red /usr/src/flowforge-nr-launcher && \
+    ln -s /usr/src/flowforge-nr-launcher /usr/src/flowfuse-nr-launcher
 
 USER node-red
-RUN --mount=type=secret,id=npm,uid=1000,target=/usr/src/node-red/.npmrc npm install npm install @flowfuse/nr-launcher@${BUILD_TAG} --omit=dev --no-audit --no-fund
+RUN --mount=type=secret,id=npm,uid=1000,target=/usr/src/node-red/.npmrc npm install @flowfuse/nr-launcher@${BUILD_TAG} --omit=dev --no-audit --no-fund
 
 USER root
-RUN mkdir -p /data/storage
-RUN chmod -R g+w /data/* /data/.npm/* 
-RUN chown -R node-red:root /data/* /data/.npm/* 
+RUN mkdir -p /data/storage && \
+    chmod -R g+w /data/* /data/.npm/* && \ 
+    chown -R node-red:root /data/* /data/.npm/* 
 
 USER node-red
 

--- a/node-red-container/Dockerfile-4.1
+++ b/node-red-container/Dockerfile-4.1
@@ -3,8 +3,8 @@ FROM nodered/node-red:4.1.11-22
 ARG BUILD_TAG=latest
 
 USER root
-RUN npm install -g npm
-RUN chown -R 1000:1000 "/data/.npm"
+RUN npm install -g npm && \
+    chown -R 1000:1000 "/data/.npm"
 
 USER node-red
 
@@ -12,23 +12,23 @@ COPY healthcheck.js /healthcheck.js
 
 COPY package.json /data
 WORKDIR /data
-RUN mkdir node_modules
-RUN npm install --omit=dev --no-audit --no-fund
+RUN mkdir node_modules && \
+    npm install --omit=dev --no-audit --no-fund
 
 USER root
 RUN mkdir -p /usr/local/ssl-certs
 
 WORKDIR /usr/src/flowforge-nr-launcher
-RUN chown -R node-red:node-red /usr/src/flowforge-nr-launcher
-RUN ln -s /usr/src/flowforge-nr-launcher /usr/src/flowfuse-nr-launcher
+RUN chown -R node-red:node-red /usr/src/flowforge-nr-launcher && \
+    ln -s /usr/src/flowforge-nr-launcher /usr/src/flowfuse-nr-launcher
 
 USER node-red
-RUN --mount=type=secret,id=npm,uid=1000,target=/usr/src/node-red/.npmrc npm install npm install @flowfuse/nr-launcher@${BUILD_TAG} --omit=dev --no-audit --no-fund
+RUN --mount=type=secret,id=npm,uid=1000,target=/usr/src/node-red/.npmrc npm install @flowfuse/nr-launcher@${BUILD_TAG} --omit=dev --no-audit --no-fund
 
 USER root
-RUN mkdir -p /data/storage
-RUN chmod -R g+w /data/* /data/.npm/* 
-RUN chown -R node-red:root /data/* /data/.npm/* 
+RUN mkdir -p /data/storage && \
+    chmod -R g+w /data/* /data/.npm/* && \ 
+    chown -R node-red:root /data/* /data/.npm/* 
 
 USER node-red
 

--- a/node-red-container/Dockerfile-5.0
+++ b/node-red-container/Dockerfile-5.0
@@ -1,0 +1,41 @@
+# TODO: set proper tag after Node-RED 5 release
+FROM nodered/node-red:5.0.0-22 
+
+ARG BUILD_TAG=latest
+
+USER root
+RUN npm install -g npm && \
+    chown -R 1000:1000 "/data/.npm"
+
+USER node-red
+
+COPY healthcheck.js /healthcheck.js
+
+COPY package.json /data
+WORKDIR /data
+RUN mkdir node_modules && \
+    npm install --omit=dev --no-audit --no-fund
+
+USER root
+RUN mkdir -p /usr/local/ssl-certs
+
+WORKDIR /usr/src/flowforge-nr-launcher
+RUN chown -R node-red:node-red /usr/src/flowforge-nr-launcher && \
+    ln -s /usr/src/flowforge-nr-launcher /usr/src/flowfuse-nr-launcher
+
+USER node-red
+RUN --mount=type=secret,id=npm,uid=1000,target=/usr/src/node-red/.npmrc npm install @flowfuse/nr-launcher@${BUILD_TAG} --omit=dev --no-audit --no-fund
+
+USER root
+RUN mkdir -p /data/storage && \
+    chmod -R g+w /data/* /data/.npm/* && \ 
+    chown -R node-red:root /data/* /data/.npm/* 
+
+USER node-red
+
+ENV NODE_PATH=/usr/src/node-red
+ENV HOME=/usr/src/node-red
+
+EXPOSE 2880
+
+ENTRYPOINT ["./node_modules/.bin/flowfuse-node-red", "-p", "2880", "-n", "/usr/src/node-red"]

--- a/node-red-container/Dockerfile-5.0
+++ b/node-red-container/Dockerfile-5.0
@@ -1,5 +1,5 @@
 # TODO: set proper tag after Node-RED 5 release
-FROM nodered/node-red:5.0.0-22 
+FROM nodered/node-red:5.0.0-24 
 
 ARG BUILD_TAG=latest
 


### PR DESCRIPTION
## Description

This pull request ensures that the FlowFuse-flavored Node-RED 5 container is built and released by adding the proper jobs to the Release container images workflow.

## Related Issue(s)

Blocked by: https://github.com/FlowFuse/helm/pull/936
Closes https://github.com/FlowFuse/helm/issues/934

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

