### PR TITLE
feat: Add possibility to specify custom broker replica number

### DIFF
--- a/helm/flowfuse/README.md
+++ b/helm/flowfuse/README.md
@@ -128,6 +128,7 @@ To use STMP to send email
 ### Team Broker
 
   - `broker.image` defines the container image for the Team Broker (default `emqx:5`)
+  - `broker.replicas` number of broker replicas (default `2`)
   - `broker.revisionHistoryLimit` number of old ControllerRevisions to retain for the EMQX team broker. If not set, uses `forge.revisionHistoryLimit` (default `10`).
   - `broker.storageClassName` the StorageClass to use for the teamBroker persistent Storage
   - `broker.listenersServiceTemplate` Service spec for the MQTT listeners

--- a/helm/flowfuse/templates/emqx.yaml
+++ b/helm/flowfuse/templates/emqx.yaml
@@ -29,6 +29,7 @@ spec:
               - name: {{ . }}
             {{- end }}
             {{- end }}
+            replicas: {{ .Values.broker.replicas | default 2 }}
             env:
               - name: EMQX_DASHBOARD__DEFAULT_PASSWORD
                 valueFrom:

--- a/helm/flowfuse/tests/broker_test.yaml
+++ b/helm/flowfuse/tests/broker_test.yaml
@@ -51,6 +51,31 @@ tests:
           path: spec.revisionHistoryLimit
           value: 5
 
+  - it: should default the EMQX core replicas to 2
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.coreTemplate.spec.replicas
+          value: 2
+
+  - it: should honor a custom broker.replicas value
+    documentIndex: 0
+    set:
+      broker.replicas: 3
+    asserts:
+      - equal:
+          path: spec.coreTemplate.spec.replicas
+          value: 3
+
+  - it: should fall back to 2 replicas when broker.replicas is null
+    documentIndex: 0
+    set:
+      broker.replicas: null
+    asserts:
+      - equal:
+          path: spec.coreTemplate.spec.replicas
+          value: 2
+
   - it: should generate the emqx-config-secrets secret when no existingSecret is set
     documentSelector:
       path: metadata.name

--- a/helm/flowfuse/values.schema.json
+++ b/helm/flowfuse/values.schema.json
@@ -1155,6 +1155,10 @@
                 "image": {
                     "type": "string"
                 },
+                "replicas": {
+                    "type": "integer",
+                    "minimum": 1
+                },
                 "revisionHistoryLimit": {
                     "type": ["integer", "null"],
                     "minimum": 0

--- a/helm/flowfuse/values.yaml
+++ b/helm/flowfuse/values.yaml
@@ -175,6 +175,7 @@ editors:
 
 broker:
   image: emqx:5
+  replicas: 2
   revisionHistoryLimit: null
   storageClassName: ''
   listenersServiceTemplate: {}


### PR DESCRIPTION
## Description

This pull request extends MQTT broker configuration by adding the possibility to define custom cluster size.

## Related Issue(s)

Closes https://github.com/FlowFuse/helm/issues/941

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

