### PR TITLE
fix: Ensure Expert Insights can be configured with values

### DIFF
--- a/helm/flowfuse/README.md
+++ b/helm/flowfuse/README.md
@@ -301,6 +301,7 @@ Everything under `forge.rate_limits` is used as input to Fastify Rate Limit plug
  - `forge.expert.service.requestTimeout` Timeout for the FlowFuse Expert service (default `60000`)
  - `forge.expert.broker.address` Address of the MQTT broker to use for communication with the Expert service (default not set). Requires `forge.broker.teamBroker.enabled=true`, since the local team broker bridges to this central broker.
  - `forge.expert.broker.port` Port of the MQTT broker to use for communication with the Expert service (default `8883`)
+ - `forge.expert.insights.enabled` Enable/disable FlowFuse Expert Insights feature (default `false`)
 
 ### AI
 

--- a/helm/flowfuse/values.schema.json
+++ b/helm/flowfuse/values.schema.json
@@ -941,6 +941,14 @@
                                     "maximum": 65535
                                 }
                             }
+                        },
+                        "insights": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                }
+                            }
                         }
                     }
                 },


### PR DESCRIPTION
## Description

This pull request updates values schema file and Helm chart docs to ensure, that FlowFuse Expert Insights feature can be configured.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

