### PR TITLE
feat: Default Expert central broker when Team Broker is enabled

### DIFF
--- a/helm/flowfuse/templates/configmap.yaml
+++ b/helm/flowfuse/templates/configmap.yaml
@@ -340,12 +340,12 @@ data:
         token: <%= ENV['EXPERT_TOKEN'] %>
         url: {{ ((.Values.forge.expert).service).url }}
         requestTimeout: {{ .Values.forge.expert.requestTimeout | default 60000 }}
-      {{- if ((.Values.forge.expert).broker).address }}
-      {{- if not ((.Values.forge.broker.teamBroker).enabled) }}
-      {{- fail "forge.expert.broker requires the Team Broker to be enabled (forge.broker.teamBroker.enabled=true)" -}}
-      {{- end }}
+      {{- $expertBrokerAddress := (((.Values.forge.expert).broker).address) }}
+      {{- if ((.Values.forge.broker.teamBroker).enabled) }}
       centralBroker:
-        server: {{ printf "%s:%v" .Values.forge.expert.broker.address (.Values.forge.expert.broker.port | default 8883) }}
+        server: {{ printf "%s:%v" ($expertBrokerAddress | default "expert-broker.flowfuse.com") (((.Values.forge.expert).broker).port | default 8883) }}
+      {{- else if $expertBrokerAddress }}
+      {{- fail "forge.expert.broker requires the Team Broker to be enabled (forge.broker.teamBroker.enabled=true)" -}}
       {{- end }}
       {{- end }}
     {{- end }}


### PR DESCRIPTION
## Description

When the Team Broker is enabled, the Expert chat uses the MQTT bridge, which needs `expert.centralBroker.server`. Today the chart only emits that key if `forge.expert.broker.address` is set, so operators have to configure it by hand even though the value is effectively always `expert-broker.flowfuse.com:8883`.

This defaults `centralBroker.server` to `expert-broker.flowfuse.com:8883` whenever Expert and the Team Broker are both enabled, matching the docker-compose template. Team Broker enabled is exactly the case where the frontend selects MQTT chat and needs the bridge, and the chart already auto-wires the `teamBroker.api` credentials in that case, so this completes the picture.

Keeping it overridable rather than hardcoded is ease of development and future proofing: the address is `expert-broker.flowfuse.com` for every hosted deployment today, but could differ later if we allow the central broker to live in a user's own deployment.

## Cases

- Team Broker enabled, no address set -> `centralBroker.server: expert-broker.flowfuse.com:8883` (the new default)
- `forge.expert.broker.address` / `port` set -> still respected as an override
- Team Broker disabled, no address -> nothing emitted, chat uses the HTTP service url
- Team Broker disabled with an explicit address -> still fails with the existing message pointing at `forge.broker.teamBroker.enabled=true`

## Related

Follow-up from a self-hosted support case where the central broker had to be configured manually. Companion PRs: FlowFuse/docker-compose#360, FlowFuse/website#5485.