### PR TITLE
fix: Require broker.enabled for Expert central broker default

### DIFF
--- a/helm/flowfuse/templates/configmap.yaml
+++ b/helm/flowfuse/templates/configmap.yaml
@@ -341,11 +341,11 @@ data:
         url: {{ ((.Values.forge.expert).service).url }}
         requestTimeout: {{ .Values.forge.expert.requestTimeout | default 60000 }}
       {{- $expertBrokerAddress := (((.Values.forge.expert).broker).address) }}
-      {{- if ((.Values.forge.broker.teamBroker).enabled) }}
+      {{- if (and .Values.forge.broker.enabled ((.Values.forge.broker.teamBroker).enabled)) }}
       centralBroker:
         server: {{ printf "%s:%v" ($expertBrokerAddress | default "expert-broker.flowfuse.com") (((.Values.forge.expert).broker).port | default 8883) }}
       {{- else if $expertBrokerAddress }}
-      {{- fail "forge.expert.broker requires the Team Broker to be enabled (forge.broker.teamBroker.enabled=true)" -}}
+      {{- fail "forge.expert.broker requires the Team Broker to be enabled (forge.broker.enabled=true and forge.broker.teamBroker.enabled=true)" -}}
       {{- end }}
       {{- end }}
     {{- end }}

--- a/helm/flowfuse/tests/expert_central_broker_test.yaml
+++ b/helm/flowfuse/tests/expert_central_broker_test.yaml
@@ -41,6 +41,7 @@ tests:
   - it: should render central broker server when expert is enabled with broker address and port
     template: configmap.yaml
     set:
+      forge.broker.enabled: true
       forge.broker.teamBroker.enabled: true
       forge.expert:
         enabled: true
@@ -61,6 +62,7 @@ tests:
   - it: should render central broker server with custom port
     template: configmap.yaml
     set:
+      forge.broker.enabled: true
       forge.broker.teamBroker.enabled: true
       forge.expert:
         enabled: true
@@ -78,6 +80,7 @@ tests:
   - it: should default the central broker port to 8883 when not provided
     template: configmap.yaml
     set:
+      forge.broker.enabled: true
       forge.broker.teamBroker.enabled: true
       forge.expert:
         enabled: true
@@ -104,7 +107,7 @@ tests:
           port: 1883
     asserts:
       - failedTemplate:
-          errorMessage: "forge.expert.broker requires the Team Broker to be enabled (forge.broker.teamBroker.enabled=true)"
+          errorMessage: "forge.expert.broker requires the Team Broker to be enabled (forge.broker.enabled=true and forge.broker.teamBroker.enabled=true)"
 
   - it: should fail when expert broker address is set and team broker is explicitly disabled
     template: configmap.yaml
@@ -120,4 +123,37 @@ tests:
           port: 1883
     asserts:
       - failedTemplate:
-          errorMessage: "forge.expert.broker requires the Team Broker to be enabled (forge.broker.teamBroker.enabled=true)"
+          errorMessage: "forge.expert.broker requires the Team Broker to be enabled (forge.broker.enabled=true and forge.broker.teamBroker.enabled=true)"
+
+  - it: should default the central broker server when team broker is enabled and no address is set
+    template: configmap.yaml
+    set:
+      forge.broker.enabled: true
+      forge.broker.teamBroker.enabled: true
+      forge.expert:
+        enabled: true
+        service:
+          url: "https://expert.example.com"
+          token: "expert-token"
+    asserts:
+      - matchRegex:
+          path: data["flowforge.yml"]
+          pattern: "server: expert-broker\\.flowfuse\\.com:8883"
+
+  - it: should not render central broker when team broker is enabled but broker is disabled
+    template: configmap.yaml
+    set:
+      forge.broker.enabled: false
+      forge.broker.teamBroker.enabled: true
+      forge.expert:
+        enabled: true
+        service:
+          url: "https://expert.example.com"
+          token: "expert-token"
+    asserts:
+      - matchRegex:
+          path: data["flowforge.yml"]
+          pattern: "expert:"
+      - notMatchRegex:
+          path: data["flowforge.yml"]
+          pattern: "centralBroker:"


### PR DESCRIPTION
Follow-up to #991.

The Team Broker configuration only renders when `forge.broker.enabled` is `true` (the whole `broker:` block in `configmap.yaml` is gated on it). The central broker default added in #991 was gated only on `forge.broker.teamBroker.enabled`, so enabling just the team broker flag while `forge.broker.enabled` was `false` emitted an `expert.centralBroker.server` with no team broker to bridge from.

This gates the default (and the accompanying guard) on both flags.

Rendered cases (`helm template`):

- `broker.enabled=true` + `teamBroker.enabled=true` → `centralBroker.server: expert-broker.flowfuse.com:8883`
- `broker.enabled=false` + `teamBroker.enabled=true` → no `centralBroker` emitted (previously emitted incorrectly)
- `broker.enabled=true` + `teamBroker.enabled=true` + explicit `expert.broker.address`/`port` → override respected
- `broker.enabled=true` + `teamBroker.enabled=false` + explicit `expert.broker.address` → fails with guidance to enable both flags
- both disabled + no address → nothing emitted (HTTP path)