### PR TITLE
feat: Add possibility to configure Team Broker resources

### DIFF
--- a/helm/flowfuse/README.md
+++ b/helm/flowfuse/README.md
@@ -147,6 +147,7 @@ To use STMP to send email
   - `broker.service.mqtt.nodePort` allows to set custom nodePort value for `mqtt` port when `broker.service.type` value is set to `NodePort` (default not set)
   - `broker.service.ws.nodePort` allows to set custom nodePort value for `ws` port when `broker.service.type` value is set to `NodePort` (default not set)
   - `broker.config` allows to overwrite the default Team Broker configuration
+  - `broker.resources` allows to configure [resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the Team Broker core container (default not set)
 
 ### Telemetry
 

--- a/helm/flowfuse/templates/emqx.yaml
+++ b/helm/flowfuse/templates/emqx.yaml
@@ -30,6 +30,9 @@ spec:
             {{- end }}
             {{- end }}
             replicas: {{ .Values.broker.replicas | default 2 }}
+            {{- if .Values.broker.resources }}
+            resources: {{- toYaml .Values.broker.resources | nindent 16 }}
+            {{- end }}
             env:
               - name: EMQX_DASHBOARD__DEFAULT_PASSWORD
                 valueFrom:

--- a/helm/flowfuse/tests/broker_test.yaml
+++ b/helm/flowfuse/tests/broker_test.yaml
@@ -76,6 +76,36 @@ tests:
           path: spec.coreTemplate.spec.replicas
           value: 2
 
+  - it: should not set core resources by default
+    documentIndex: 0
+    asserts:
+      - notExists:
+          path: spec.coreTemplate.spec.resources
+
+  - it: should honor a custom broker.resources value
+    documentIndex: 0
+    set:
+      broker.resources:
+        requests:
+          cpu: 250m
+          memory: 512Mi
+        limits:
+          cpu: "1"
+          memory: 1Gi
+    asserts:
+      - equal:
+          path: spec.coreTemplate.spec.resources.requests.cpu
+          value: 250m
+      - equal:
+          path: spec.coreTemplate.spec.resources.requests.memory
+          value: 512Mi
+      - equal:
+          path: spec.coreTemplate.spec.resources.limits.cpu
+          value: "1"
+      - equal:
+          path: spec.coreTemplate.spec.resources.limits.memory
+          value: 1Gi
+
   - it: should generate the emqx-config-secrets secret when no existingSecret is set
     documentSelector:
       path: metadata.name

--- a/helm/flowfuse/values.schema.json
+++ b/helm/flowfuse/values.schema.json
@@ -1208,6 +1208,7 @@
                             }
                         }
                     }
+                },
                 "podSecurityContext": {
                     "type": "object"
                 },

--- a/helm/flowfuse/values.schema.json
+++ b/helm/flowfuse/values.schema.json
@@ -1182,6 +1182,33 @@
                     "type": "integer",
                     "minimum": 1
                 },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": ["number","string"]
+                                },
+                                "memory": {
+                                    "type": ["number","string"]
+                                }
+                            }
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": ["number","string"]
+                                },
+                                "memory": {
+                                    "type": ["number","string"]
+                                }
+                            }
+                        }
+                    }
+                },
                 "revisionHistoryLimit": {
                     "type": ["integer", "null"],
                     "minimum": 0

--- a/helm/flowfuse/values.yaml
+++ b/helm/flowfuse/values.yaml
@@ -183,6 +183,7 @@ editors:
 broker:
   image: emqx:5.8.6
   replicas: 2
+  resources: {}
   revisionHistoryLimit: null
   storageClassName: ''
   listenersServiceTemplate: {}


### PR DESCRIPTION
## Description

This pull request introduces the `broker.resources` value that can be used to configure resources used by the Team Broker pods.

## Related Issue(s)

https://github.com/FlowFuse/helm/issues/1000

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

