### PR TITLE
feat: Add possibility to configure security contexts for Team Broker pods and containers

### DIFF
--- a/helm/flowfuse/README.md
+++ b/helm/flowfuse/README.md
@@ -147,6 +147,8 @@ To use STMP to send email
   - `broker.service.mqtt.nodePort` allows to set custom nodePort value for `mqtt` port when `broker.service.type` value is set to `NodePort` (default not set)
   - `broker.service.ws.nodePort` allows to set custom nodePort value for `ws` port when `broker.service.type` value is set to `NodePort` (default not set)
   - `broker.config` allows to overwrite the default Team Broker configuration
+  - `broker.podSecurityContext` allows to configure pod-level [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the Team Broker core pods (default not set)
+  - `broker.containerSecurityContext` allows to configure container-level [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the Team Broker core container (default not set)
 
 ### Telemetry
 

--- a/helm/flowfuse/templates/emqx.yaml
+++ b/helm/flowfuse/templates/emqx.yaml
@@ -30,6 +30,12 @@ spec:
             {{- end }}
             {{- end }}
             replicas: {{ .Values.broker.replicas | default 2 }}
+            {{- if .Values.broker.podSecurityContext }}
+            podSecurityContext: {{- toYaml .Values.broker.podSecurityContext | nindent 16 }}
+            {{- end }}
+            {{- if .Values.broker.containerSecurityContext }}
+            containerSecurityContext: {{- toYaml .Values.broker.containerSecurityContext | nindent 16 }}
+            {{- end }}
             env:
               - name: EMQX_DASHBOARD__DEFAULT_PASSWORD
                 valueFrom:

--- a/helm/flowfuse/tests/broker_test.yaml
+++ b/helm/flowfuse/tests/broker_test.yaml
@@ -76,6 +76,47 @@ tests:
           path: spec.coreTemplate.spec.replicas
           value: 2
 
+  - it: should not set core pod or container security context by default
+    documentIndex: 0
+    asserts:
+      - notExists:
+          path: spec.coreTemplate.spec.podSecurityContext
+      - notExists:
+          path: spec.coreTemplate.spec.containerSecurityContext
+
+  - it: should honor a custom broker.podSecurityContext value
+    documentIndex: 0
+    set:
+      broker.podSecurityContext:
+        runAsUser: 1000710000
+        fsGroup: 1000710000
+        seccompProfile:
+          type: RuntimeDefault
+    asserts:
+      - equal:
+          path: spec.coreTemplate.spec.podSecurityContext.runAsUser
+          value: 1000710000
+      - equal:
+          path: spec.coreTemplate.spec.podSecurityContext.seccompProfile.type
+          value: RuntimeDefault
+
+  - it: should honor a custom broker.containerSecurityContext value
+    documentIndex: 0
+    set:
+      broker.containerSecurityContext:
+        runAsNonRoot: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+    asserts:
+      - equal:
+          path: spec.coreTemplate.spec.containerSecurityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.coreTemplate.spec.containerSecurityContext.capabilities.drop[0]
+          value: ALL
+
   - it: should generate the emqx-config-secrets secret when no existingSecret is set
     documentSelector:
       path: metadata.name

--- a/helm/flowfuse/values.schema.json
+++ b/helm/flowfuse/values.schema.json
@@ -1182,6 +1182,12 @@
                     "type": "integer",
                     "minimum": 1
                 },
+                "podSecurityContext": {
+                    "type": "object"
+                },
+                "containerSecurityContext": {
+                    "type": "object"
+                },
                 "revisionHistoryLimit": {
                     "type": ["integer", "null"],
                     "minimum": 0

--- a/helm/flowfuse/values.yaml
+++ b/helm/flowfuse/values.yaml
@@ -183,6 +183,8 @@ editors:
 broker:
   image: emqx:5.8.6
   replicas: 2
+  podSecurityContext: {}
+  containerSecurityContext: {}
   revisionHistoryLimit: null
   storageClassName: ''
   listenersServiceTemplate: {}


### PR DESCRIPTION
## Description

This pull request introduces the `broker.podSecurityContext` and `broker.containerSecurityContext` values that can be used to configure the security context for Team Broker pod and container.

## Related Issue(s)

https://github.com/FlowFuse/helm/issues/1000

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

