### PR TITLE
feat: Add possibility to customize Team Broker pod labels

### DIFF
--- a/helm/flowfuse/README.md
+++ b/helm/flowfuse/README.md
@@ -149,6 +149,7 @@ To use STMP to send email
   - `broker.config` allows to overwrite the default Team Broker configuration
   - `broker.podSecurityContext` allows to configure pod-level [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the Team Broker core pods (default not set)
   - `broker.containerSecurityContext` allows to configure container-level [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the Team Broker core container (default not set)
+  - `broker.podLabels` allows to add custom labels to the Team Broker core pods (default `{}`). Setting this rolls the broker core pods, and the keys must not start with `apps.emqx.io/`.
 
 ### Telemetry
 

--- a/helm/flowfuse/templates/emqx.yaml
+++ b/helm/flowfuse/templates/emqx.yaml
@@ -22,6 +22,10 @@ spec:
                 secretName: emqx-config-secrets
                 secretKey: api_key_secret
     coreTemplate:
+        {{- with .Values.broker.podLabels }}
+        metadata:
+            labels: {{- toYaml . | nindent 16 }}
+        {{- end }}
         spec:
             {{- if .Values.forge.registrySecrets }}
             imagePullSecrets:

--- a/helm/flowfuse/tests/broker_test.yaml
+++ b/helm/flowfuse/tests/broker_test.yaml
@@ -117,6 +117,25 @@ tests:
           path: spec.coreTemplate.spec.containerSecurityContext.capabilities.drop[0]
           value: ALL
 
+  - it: should not set core pod labels by default
+    documentIndex: 0
+    asserts:
+      - notExists:
+          path: spec.coreTemplate.metadata
+
+  - it: should honor custom broker.podLabels
+    documentIndex: 0
+    set:
+      broker.podLabels:
+        app.kubernetes.io/name: flowforge
+        team: platform
+    asserts:
+      - equal:
+          path: spec.coreTemplate.metadata.labels
+          value:
+            app.kubernetes.io/name: flowforge
+            team: platform
+
   - it: should generate the emqx-config-secrets secret when no existingSecret is set
     documentSelector:
       path: metadata.name

--- a/helm/flowfuse/values.schema.json
+++ b/helm/flowfuse/values.schema.json
@@ -1188,6 +1188,9 @@
                 "containerSecurityContext": {
                     "type": "object"
                 },
+                "podLabels": {
+                    "type": "object"
+                },
                 "revisionHistoryLimit": {
                     "type": ["integer", "null"],
                     "minimum": 0

--- a/helm/flowfuse/values.yaml
+++ b/helm/flowfuse/values.yaml
@@ -185,6 +185,7 @@ broker:
   replicas: 2
   podSecurityContext: {}
   containerSecurityContext: {}
+  podLabels: {}
   revisionHistoryLimit: null
   storageClassName: ''
   listenersServiceTemplate: {}


### PR DESCRIPTION
## Description

This pull request introduces the `broker.podLabels` value that allows to set custom labels for Team Broker pods.

## Related Issue(s)

https://github.com/FlowFuse/helm/issues/1000

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

