### PR TITLE
feat: Add possibility to configure Team Broker probes

### DIFF
--- a/helm/flowfuse/README.md
+++ b/helm/flowfuse/README.md
@@ -150,6 +150,21 @@ To use STMP to send email
   - `broker.podSecurityContext` allows to configure pod-level [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the Team Broker core pods (default not set)
   - `broker.containerSecurityContext` allows to configure container-level [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the Team Broker core container (default not set)
   - `broker.podLabels` allows to add custom labels to the Team Broker core pods (default `{}`). Setting this rolls the broker core pods, and the keys must not start with `apps.emqx.io/`.
+  - `broker.livenessProbe` allows to configure [livenessProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) for the Team Broker core container (default not set)
+  - `broker.readinessProbe` allows to configure [readinessProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) for the Team Broker core container (default not set)
+  - `broker.startupProbe` allows to configure [startupProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) for the Team Broker core container (default not set)
+
+  Each probe is passed through as given, so provide a complete definition including a handler, for example:
+
+  ```yaml
+  broker:
+    livenessProbe:
+      httpGet:
+        path: /status
+        port: dashboard
+      initialDelaySeconds: 90
+      periodSeconds: 30
+  ```
 
 ### Telemetry
 

--- a/helm/flowfuse/templates/emqx.yaml
+++ b/helm/flowfuse/templates/emqx.yaml
@@ -40,6 +40,15 @@ spec:
             {{- if .Values.broker.containerSecurityContext }}
             containerSecurityContext: {{- toYaml .Values.broker.containerSecurityContext | nindent 16 }}
             {{- end }}
+            {{- with .Values.broker.livenessProbe }}
+            livenessProbe: {{- toYaml . | nindent 16 }}
+            {{- end }}
+            {{- with .Values.broker.readinessProbe }}
+            readinessProbe: {{- toYaml . | nindent 16 }}
+            {{- end }}
+            {{- with .Values.broker.startupProbe }}
+            startupProbe: {{- toYaml . | nindent 16 }}
+            {{- end }}
             env:
               - name: EMQX_DASHBOARD__DEFAULT_PASSWORD
                 valueFrom:

--- a/helm/flowfuse/tests/broker_test.yaml
+++ b/helm/flowfuse/tests/broker_test.yaml
@@ -136,6 +136,51 @@ tests:
             app.kubernetes.io/name: flowforge
             team: platform
 
+  - it: should not set core probes by default
+    documentIndex: 0
+    asserts:
+      - notExists:
+          path: spec.coreTemplate.spec.livenessProbe
+      - notExists:
+          path: spec.coreTemplate.spec.readinessProbe
+      - notExists:
+          path: spec.coreTemplate.spec.startupProbe
+
+  - it: should honor custom broker probes
+    documentIndex: 0
+    set:
+      broker.livenessProbe:
+        httpGet:
+          path: /status
+          port: dashboard
+        initialDelaySeconds: 90
+        periodSeconds: 30
+      broker.readinessProbe:
+        httpGet:
+          path: /status
+          port: dashboard
+        initialDelaySeconds: 15
+        failureThreshold: 20
+      broker.startupProbe:
+        httpGet:
+          path: /status
+          port: dashboard
+        failureThreshold: 30
+        periodSeconds: 10
+    asserts:
+      - equal:
+          path: spec.coreTemplate.spec.livenessProbe.initialDelaySeconds
+          value: 90
+      - equal:
+          path: spec.coreTemplate.spec.livenessProbe.httpGet.port
+          value: dashboard
+      - equal:
+          path: spec.coreTemplate.spec.readinessProbe.failureThreshold
+          value: 20
+      - equal:
+          path: spec.coreTemplate.spec.startupProbe.failureThreshold
+          value: 30
+
   - it: should generate the emqx-config-secrets secret when no existingSecret is set
     documentSelector:
       path: metadata.name

--- a/helm/flowfuse/values.schema.json
+++ b/helm/flowfuse/values.schema.json
@@ -1191,6 +1191,15 @@
                 "podLabels": {
                     "type": "object"
                 },
+                "livenessProbe": {
+                    "type": "object"
+                },
+                "readinessProbe": {
+                    "type": "object"
+                },
+                "startupProbe": {
+                    "type": "object"
+                },
                 "revisionHistoryLimit": {
                     "type": ["integer", "null"],
                     "minimum": 0

--- a/helm/flowfuse/values.yaml
+++ b/helm/flowfuse/values.yaml
@@ -186,6 +186,9 @@ broker:
   podSecurityContext: {}
   containerSecurityContext: {}
   podLabels: {}
+  livenessProbe: {}
+  readinessProbe: {}
+  startupProbe: {}
   revisionHistoryLimit: null
   storageClassName: ''
   listenersServiceTemplate: {}


### PR DESCRIPTION
## Description

This pull request introduces `broker.livenessProbe`, `broker.readinessProbe` and `broker.startupProbe` values that can be used to configure health probes used by the Team Broker pods.

## Related Issue(s)

https://github.com/FlowFuse/helm/issues/1000

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

