### PR TITLE
feat: Add possibility to configure Google Tag Manager as part of the telemetry

### DIFF
--- a/helm/flowfuse/README.md
+++ b/helm/flowfuse/README.md
@@ -180,6 +180,7 @@ Enables FlowFuse Telemetry
  - `forge.telemetry.sentry.production_mode` rate limit reporting (default `true`)
  - `forge.telemetry.sentry.environment` set SENTRY_ENV environment variable, which overrides NODE_ENV for the reported environment (default unset)
  - `forge.telemetry.google.tag` a Google Analytics Tag Account ID (default unset)
+ - `forge.telemetry.google.gtm` a Google Tag Manager container ID (default unset)
  - `forge.telemetry.google.events` an object containing keys matching events to track and values to be included (default unset)
  - `forge.telemetry.backend.prometheus.enabled` enables the `/metrics` endpoint on the forge app for scraping by Prometheus
 

--- a/helm/flowfuse/templates/configmap.yaml
+++ b/helm/flowfuse/templates/configmap.yaml
@@ -233,7 +233,7 @@ data:
       http: {{ .Values.forge.logging.http }}
     telemetry:
       enabled: {{ .Values.forge.telemetry.enabled }}
-      {{ if or (.Values.forge.telemetry.plausible) (.Values.forge.telemetry.posthog) (and (hasKey .Values.forge.telemetry "sentry") (hasKey .Values.forge.telemetry.sentry "frontend_dsn")) }}
+      {{ if or (.Values.forge.telemetry.plausible) (.Values.forge.telemetry.posthog) (and (hasKey .Values.forge.telemetry "sentry") (hasKey .Values.forge.telemetry.sentry "frontend_dsn")) (and (hasKey .Values.forge.telemetry "google") (or (hasKey .Values.forge.telemetry.google "tag") (hasKey .Values.forge.telemetry.google "gtm"))) }}
       frontend:
         {{ if .Values.forge.telemetry.plausible -}}
         plausible:
@@ -260,9 +260,14 @@ data:
           production_mode: true
           {{ end }}
         {{ end -}}
-        {{ if and (hasKey .Values.forge.telemetry "google") (hasKey .Values.forge.telemetry.google "tag") }}
+        {{ if and (hasKey .Values.forge.telemetry "google") (or (hasKey .Values.forge.telemetry.google "tag") (hasKey .Values.forge.telemetry.google "gtm")) }}
         google:
+          {{ if hasKey .Values.forge.telemetry.google "tag" -}}
           tag: {{ .Values.forge.telemetry.google.tag }}
+          {{ end -}}
+          {{ if hasKey .Values.forge.telemetry.google "gtm" -}}
+          gtm: {{ .Values.forge.telemetry.google.gtm }}
+          {{ end -}}
           {{ if hasKey .Values.forge.telemetry.google "events" }}
           events:
 {{ toYaml .Values.forge.telemetry.google.events | indent 12 }}

--- a/helm/flowfuse/tests/configmap_test.yaml
+++ b/helm/flowfuse/tests/configmap_test.yaml
@@ -98,6 +98,66 @@ tests:
           path: data["flowforge.yml"]
           pattern: "production_mode: false"
 
+  - it: should render Google Analytics tag without a Tag Manager container
+    set:
+      forge.telemetry.google:
+        tag: G-TESTTAG
+    asserts:
+      - matchRegex:
+          path: data["flowforge.yml"]
+          pattern: "frontend:"
+      - matchRegex:
+          path: data["flowforge.yml"]
+          pattern: "google:\\n\\s+tag: G-TESTTAG"
+      - notMatchRegex:
+          path: data["flowforge.yml"]
+          pattern: "gtm:"
+
+  - it: should render Google Analytics events
+    set:
+      forge.telemetry.google:
+        tag: G-TESTTAG
+        events:
+          signup: true
+    asserts:
+      - matchRegex:
+          path: data["flowforge.yml"]
+          pattern: "google:\\n\\s+tag: G-TESTTAG\\n\\s+events:\\n\\s+signup: true"
+
+  - it: should render Google Tag Manager container without an Analytics tag
+    set:
+      forge.telemetry.google:
+        gtm: GTM-ABC123
+    asserts:
+      - matchRegex:
+          path: data["flowforge.yml"]
+          pattern: "frontend:"
+      - matchRegex:
+          path: data["flowforge.yml"]
+          pattern: "google:\\n\\s+gtm: GTM-ABC123"
+      - notMatchRegex:
+          path: data["flowforge.yml"]
+          pattern: "tag:"
+
+  - it: should render both Analytics tag and Google Tag Manager container
+    set:
+      forge.telemetry.google:
+        tag: G-TESTTAG
+        gtm: GTM-ABC123
+    asserts:
+      - matchRegex:
+          path: data["flowforge.yml"]
+          pattern: "google:\\n\\s+tag: G-TESTTAG\\n\\s+gtm: GTM-ABC123"
+
+  - it: should not render google telemetry by default
+    asserts:
+      - notMatchRegex:
+          path: data["flowforge.yml"]
+          pattern: "google:"
+      - notMatchRegex:
+          path: data["flowforge.yml"]
+          pattern: "gtm:"
+
   - it: should render prometheus enabled in backend telemetry
     set:
       forge.telemetry.backend.prometheus.enabled: true

--- a/helm/flowfuse/values.schema.json
+++ b/helm/flowfuse/values.schema.json
@@ -382,11 +382,11 @@
                                 },
                                 "events": {
                                     "type": "object"
+                                },
+                                "gtm": {
+                                    "type": "string"
                                 }
-                            },
-                            "required": [
-                                "tag"
-                            ]
+                            }
                         },
                         "backend": {
                             "type": "object",


### PR DESCRIPTION
## Description

This pull request introduces the `forge.telemetry.google.gtm` configuration value that allows to specify Google Tag Manager container ID.

## Related Issue(s)

Closes https://github.com/FlowFuse/helm/issues/1008

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

