### PR TITLE
feat: Enable MQTT broker and Team Broker feature by default

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -97,9 +97,16 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
 
+      - name: Install EMQX Operator CRDs
+        run: |
+          helm repo add emqx https://repos.emqx.io/charts
+          helm repo update
+          helm template emqx-operator emqx/emqx-operator --include-crds -s templates/crds.yaml \
+            | kubectl apply --server-side -f -
+
       - name: Validate chart
         run: |
-          helm template flowfuse ./helm/flowfuse --set forge.domain=example.com | kubectl apply --validate=true -f -
+          helm template flowfuse ./helm/flowfuse --set forge.domain=example.com --api-versions apps.emqx.io/v2beta1 | kubectl apply --validate=true -f -
 
   unit-tests:
     name: Run unit tests
@@ -155,7 +162,7 @@ jobs:
         uses: bridgecrewio/checkov-action@358405ddafaa109ad35d3d607bbc7cf933c742d9 # v12.3116.0
         with:
           directory: ${{ github.workspace }}/helm
-          var_file: ${{ github.workspace }}/helm/flowfuse/ci/default-values.yaml
+          var_file: ${{ github.workspace }}/helm/flowfuse/ci/ci-values.yaml
           skip_path: /flowfuse/charts/
           framework: helm
           output_format: cli,sarif

--- a/helm/flowfuse/README.md
+++ b/helm/flowfuse/README.md
@@ -2,6 +2,16 @@
 
 Access to FlowFuse Management App via the host `forge` on what ever domain is passed. e.g. if `example.com` then `http://forge.example.com`
 
+## Prerequisites
+
+The MQTT broker is installed by default, and it needs the EMQX Operator and cert-manager to be
+present in your cluster first. See the
+[installation prerequisites](https://flowfuse.com/docs/install/kubernetes/#prerequisites) for the
+full list and how to install them.
+
+If you would rather not run the broker, set `forge.broker.enabled: false` and no broker is
+installed.
+
 ## Database
 
 This chart can use the Bitnami PostgreSQL Chart to provide an instance of a PostgreSQL Database to store state (`forge.localPostgresql: true`).
@@ -111,11 +121,11 @@ To use STMP to send email
 
  ### MQTT Broker
 
-  - `forge.broker.enabled` deploys the MQTT broker (default `false`)
+  - `forge.broker.enabled` deploys the MQTT broker (default `true`)
   - `forge.broker.url` URL to access the broker from inside the cluster (default `mqtt://emqx-listeners.[namespace]:1883`)
   - `forge.broker.public_url` URL to access the broker from outside the cluster (default `ws://mqtt.[forge.domain]`, uses `wss://` if `forge.https` is `true`)
   - `forge.broker.hostname` the custom Fully Qualified Domain Name (FQDN) where the broker will be hosted (default `mqtt.[forge.domain]`)
-  - `forge.broker.teamBroker.enabled` Enables Team Broker feature (default `false`). Requires `forge.broker.enabled=true`
+  - `forge.broker.teamBroker.enabled` Enables Team Broker feature (default `true`). Requires `forge.broker.enabled=true`
   - `forge.broker.teamBroker.api.url` URL for the Team Broker API (default `http://emqx-dashboard.<release-namespace>:18083`)
   - `forge.broker.teamBroker.api.key` API key name for the Team Broker API (optional; must be set together with `api.secret`)
   - `forge.broker.teamBroker.api.secret` API secret for the Team Broker API (optional; must be set together with `api.key`)

--- a/helm/flowfuse/templates/emqx.yaml
+++ b/helm/flowfuse/templates/emqx.yaml
@@ -1,6 +1,6 @@
 {{- if eq .Values.forge.broker.enabled true -}}
 {{- if not (.Capabilities.APIVersions.Has "apps.emqx.io/v2beta1") }}
-{{- fail "EMQX Operator not installed. Please install it or disable the broker (forge.broker.enabled=false) before continuing" }}
+{{- fail "EMQX Operator not installed. Please install it or disable the broker (forge.broker.enabled=false) before continuing. See https://flowfuse.com/docs/install/kubernetes/#prerequisites for installation prerequisites." }}
 {{- end }}
 apiVersion: apps.emqx.io/v2beta1
 kind: EMQX

--- a/helm/flowfuse/tests/deployment_test.yaml
+++ b/helm/flowfuse/tests/deployment_test.yaml
@@ -35,20 +35,41 @@ tests:
           path: spec.template.spec.initContainers
           count: 1
 
-  - it: should create an init container with two secrets
+  - it: should create an init container with three secrets
     template: deployment.yaml
     asserts:
       - isNotNullOrEmpty:
           path: spec.template.spec.initContainers[0].env
       - lengthEqual:
           path: spec.template.spec.initContainers[0].env
-          count: 2
+          count: 3
       - equal:
           path: spec.template.spec.initContainers[0].env[0].name
           value: PGPASSWORD
       - equal:
           path: spec.template.spec.initContainers[0].env[1].name
           value: SMTPPASSWORD
+      - equal:
+          path: spec.template.spec.initContainers[0].env[2].name
+          value: TEAM_BROKER_API_SECRET
+      - equal:
+          path: spec.template.spec.initContainers[0].env[0].valueFrom.secretKeyRef.name
+          value: flowfuse-secrets
+      - equal:
+          path: spec.template.spec.initContainers[0].env[1].valueFrom.secretKeyRef.name
+          value: flowfuse-secrets
+      - equal:
+          path: spec.template.spec.initContainers[0].env[2].valueFrom.secretKeyRef.name
+          value: emqx-config-secrets
+
+  - it: should create an init container with two secrets when the broker is disabled
+    template: deployment.yaml
+    set:
+      forge.broker.enabled: false
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.initContainers[0].env
+          count: 2
       - equal:
           path: spec.template.spec.initContainers[0].env[*].valueFrom.secretKeyRef.name
           value: flowfuse-secrets

--- a/helm/flowfuse/tests/expert_central_broker_test.yaml
+++ b/helm/flowfuse/tests/expert_central_broker_test.yaml
@@ -22,9 +22,26 @@ tests:
           path: data["flowforge.yml"]
           pattern: "centralBroker:"
 
-  - it: should not include central broker block when expert is enabled but broker.address is not set
+  - it: should include the default central broker block when expert is enabled and broker.address is not set
     template: configmap.yaml
     set:
+      forge.expert:
+        enabled: true
+        service:
+          url: "https://expert.example.com"
+          token: "expert-token"
+    asserts:
+      - matchRegex:
+          path: data["flowforge.yml"]
+          pattern: "expert:"
+      - matchRegex:
+          path: data["flowforge.yml"]
+          pattern: "server: expert-broker\\.flowfuse\\.com:8883"
+
+  - it: should not include central broker block when team broker is explicitly disabled
+    template: configmap.yaml
+    set:
+      forge.broker.teamBroker.enabled: false
       forge.expert:
         enabled: true
         service:
@@ -94,9 +111,10 @@ tests:
           path: data["flowforge.yml"]
           pattern: "server: central-broker\\.example\\.com:8883"
 
-  - it: should fail when expert broker address is set but team broker is not enabled
+  - it: should fail when expert broker address is set and the broker is disabled
     template: configmap.yaml
     set:
+      forge.broker.enabled: false
       forge.expert:
         enabled: true
         service:

--- a/helm/flowfuse/tests/team_broker_api_test.yaml
+++ b/helm/flowfuse/tests/team_broker_api_test.yaml
@@ -7,10 +7,21 @@ templates:
 set:
   forge.domain: "chart-unit-tests.com"
 tests:
-  - it: should not include teamBroker api block when teamBroker is disabled by default
+  - it: should include the teamBroker api block by default
+    template: configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["flowforge.yml"]
+          pattern: "teamBroker:"
+      - matchRegex:
+          path: data["flowforge.yml"]
+          pattern: "TEAM_BROKER_API_SECRET"
+
+  - it: should not render teamBroker api block when teamBroker is explicitly disabled
     template: configmap.yaml
     set:
-      forge.broker.enabled: true
+      forge.broker.teamBroker:
+        enabled: false
     asserts:
       - notMatchRegex:
           path: data["flowforge.yml"]
@@ -77,10 +88,10 @@ tests:
           pattern: "secret: team-broker-secret"
 
   # Deployment tests
-  - it: should not include TEAM_BROKER_API_SECRET env var by default
+  - it: should include TEAM_BROKER_API_SECRET env var by default
     template: deployment.yaml
     asserts:
-      - notExists:
+      - exists:
           path: spec.template.spec.initContainers[0].env[?(@.name == "TEAM_BROKER_API_SECRET")]
 
   - it: should not include TEAM_BROKER_API_SECRET env var when teamBroker is disabled

--- a/helm/flowfuse/values.yaml
+++ b/helm/flowfuse/values.yaml
@@ -27,9 +27,9 @@ forge:
   labels: {}
   podLabels: {}
   broker:
-    enabled: false
+    enabled: true
     teamBroker:
-      enabled: false
+      enabled: true
     tolerations: []
     ingress.annotations: {}
   logging:


### PR DESCRIPTION
## Description

This pull request enables installation of a MQTT broker and enables Team Broker feature by default.

Following areas has been addressed as a follow-up of the change:
* unit tests adjustment
* helm chart validation CI pipeline adjustment

## Related Issue(s)

Closes https://github.com/FlowFuse/helm/issues/1010

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

