### PR TITLE
feat: Add possibility to anonymize telemetry

### DIFF
--- a/helm/flowfuse/templates/configmap.yaml
+++ b/helm/flowfuse/templates/configmap.yaml
@@ -233,6 +233,9 @@ data:
       http: {{ .Values.forge.logging.http }}
     telemetry:
       enabled: {{ .Values.forge.telemetry.enabled }}
+      {{ if hasKey .Values.forge.telemetry "anonymize" -}}
+      anonymize: {{ .Values.forge.telemetry.anonymize }}
+      {{ end -}}
       {{ if or (.Values.forge.telemetry.plausible) (.Values.forge.telemetry.posthog) (and (hasKey .Values.forge.telemetry "sentry") (hasKey .Values.forge.telemetry.sentry "frontend_dsn")) (and (hasKey .Values.forge.telemetry "google") (or (hasKey .Values.forge.telemetry.google "tag") (hasKey .Values.forge.telemetry.google "gtm"))) }}
       frontend:
         {{ if .Values.forge.telemetry.plausible -}}

--- a/helm/flowfuse/tests/configmap_test.yaml
+++ b/helm/flowfuse/tests/configmap_test.yaml
@@ -158,6 +158,31 @@ tests:
           path: data["flowforge.yml"]
           pattern: "gtm:"
 
+  - it: should render telemetry anonymize when enabled
+    set:
+      forge.telemetry.anonymize: true
+    asserts:
+      - matchRegex:
+          path: data["flowforge.yml"]
+          pattern: "telemetry:\\n\\s+enabled: true\\n\\s+anonymize: true"
+      - notMatchRegex:
+          path: data["flowforge.yml"]
+          pattern: "frontend:"
+
+  - it: should render telemetry anonymize when disabled
+    set:
+      forge.telemetry.anonymize: false
+    asserts:
+      - matchRegex:
+          path: data["flowforge.yml"]
+          pattern: "telemetry:\\n\\s+enabled: true\\n\\s+anonymize: false"
+
+  - it: should not render telemetry anonymize by default
+    asserts:
+      - notMatchRegex:
+          path: data["flowforge.yml"]
+          pattern: "anonymize:"
+
   - it: should render prometheus enabled in backend telemetry
     set:
       forge.telemetry.backend.prometheus.enabled: true


### PR DESCRIPTION
## Description

This pull request adds the option to anonymise telemetry data.
The default value (`true`) is hardcoded in the `flowfuse` codebase (https://github.com/FlowFuse/flowfuse/pull/8279). Since we do not want users to change this value by mistake, we do not document it in the README or in the values schema file.

## Related Issue(s)

https://github.com/FlowFuse/CloudProject/issues/1560

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

