### PR TITLE
ci: Wait for broker CRDs to be created before templating the Helm chart

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -103,8 +103,14 @@ jobs:
           helm repo update
           helm template emqx-operator emqx/emqx-operator --include-crds -s templates/crds.yaml \
             | kubectl apply --server-side -f -
-          kubectl wait --for=condition=Established --timeout=60s \
-            crd/emqxes.apps.emqx.io crd/rebalances.apps.emqx.io
+          # `kubectl wait` exits with an error instead of waiting if newly created CRD returns `status.conditions: null`.
+          for i in $(seq 1 30); do
+            kubectl wait --for=condition=Established --timeout=10s \
+              crd/emqxes.apps.emqx.io crd/rebalances.apps.emqx.io \
+              && exit 0
+            sleep 2
+          done
+          exit 1
 
       - name: Validate chart
         run: |

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -103,6 +103,8 @@ jobs:
           helm repo update
           helm template emqx-operator emqx/emqx-operator --include-crds -s templates/crds.yaml \
             | kubectl apply --server-side -f -
+          kubectl wait --for=condition=Established --timeout=60s \
+            crd/emqxes.apps.emqx.io crd/rebalances.apps.emqx.io
 
       - name: Validate chart
         run: |


### PR DESCRIPTION
## Description

This pull request adjusts the `Validate chart against kubernetes API` step in the `Helm chart validation` workflow and adds a wait step between applying EMQX CRDs and running `helm template` command.
This should fix error https://github.com/FlowFuse/helm/actions/runs/33005942578/job/98299573347#step:6:27  

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

